### PR TITLE
Add homepage taxonomy filter dropdowns

### DIFF
--- a/layouts/partials/sidebar/right.html
+++ b/layouts/partials/sidebar/right.html
@@ -2,6 +2,12 @@
 {{- $context := .Context -}}
 {{- with (index .Context.Site.Params.widgets $scope) -}}
     <aside class="sidebar right-sidebar sticky">
+        {{- if eq $scope "homepage" -}}
+        {{/* Homepage: taxonomy filter buttons */}}
+        <div class="right-sidebar__filters">
+            {{ partial "widget/taxonomy-filters" (dict "Context" $context) }}
+        </div>
+        {{- else -}}
         <div class="right-sidebar__layout">
             {{/* TOC column (left, closer to content) */}}
             <div class="right-sidebar__toc">
@@ -24,5 +30,6 @@
             </div>
             {{ end }}
         </div>
+        {{- end -}}
     </aside>
 {{ end }}

--- a/layouts/partials/widget/taxonomy-filters.html
+++ b/layouts/partials/widget/taxonomy-filters.html
@@ -4,6 +4,11 @@
   (dict "key" "labs"    "title" "Labs")
   (dict "key" "authors" "title" "Authors")
 -}}
+{{- $archivesQuery := first 1 (where $context.Site.Pages "Layout" "==" "archives") -}}
+{{- $archivesPage := false -}}
+{{- if $archivesQuery -}}{{ $archivesPage = index $archivesQuery 0 }}{{ end -}}
+{{- $pages := partial "helper/pages.html" $context.Site.Home -}}
+{{- $years := $pages.GroupByDate "2006" -}}
 
 <nav class="filter-bar">
   <h3 class="filter-bar__heading">Filter posts by&hellip;</h3>
@@ -24,6 +29,23 @@
       </div>
     </div>
     {{- end -}}
+  {{- end -}}
+  {{/* Year dropdown */}}
+  {{- if $years -}}
+  <div class="filter-bar__group">
+    <div class="filter-bar__dropdown">
+      <button type="button" class="action-bar__btn filter-bar__dropdown-toggle" aria-expanded="false" aria-label="Year">
+        <span class="action-bar__label">Year</span>
+        <svg class="filter-bar__chevron" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
+      </button>
+      <ul class="filter-bar__dropdown-menu" role="listbox">
+        {{- range $years -}}
+        {{- $id := lower (replace .Key " " "-") -}}
+        <li role="option"><a href="{{ if $archivesPage }}{{ $archivesPage.RelPermalink }}#{{ $id }}{{ end }}">{{ .Key }}</a></li>
+        {{- end -}}
+      </ul>
+    </div>
+  </div>
   {{- end -}}
 </nav>
 

--- a/layouts/partials/widget/taxonomy-filters.html
+++ b/layouts/partials/widget/taxonomy-filters.html
@@ -1,0 +1,49 @@
+{{- $context := .Context -}}
+{{- $taxonomies := slice
+  (dict "key" "tags"    "title" "Tags")
+  (dict "key" "labs"    "title" "Labs")
+  (dict "key" "authors" "title" "Authors")
+-}}
+
+<nav class="filter-bar">
+  <h3 class="filter-bar__heading">Filter posts by&hellip;</h3>
+  {{- range $tax := $taxonomies -}}
+    {{- $terms := index $context.Site.Taxonomies .key -}}
+    {{- if $terms -}}
+    <div class="filter-bar__group">
+      <div class="filter-bar__dropdown">
+        <button type="button" class="action-bar__btn filter-bar__dropdown-toggle" aria-expanded="false" aria-label="{{ .title }}">
+          <span class="action-bar__label">{{ .title }}</span>
+          <svg class="filter-bar__chevron" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
+        </button>
+        <ul class="filter-bar__dropdown-menu" role="listbox">
+          {{- range $terms.ByCount -}}
+          <li role="option"><a href="{{ .Page.RelPermalink }}">{{ .Page.Title }}</a></li>
+          {{- end -}}
+        </ul>
+      </div>
+    </div>
+    {{- end -}}
+  {{- end -}}
+</nav>
+
+<script>
+(function() {
+  document.querySelectorAll('.filter-bar__dropdown-toggle').forEach(function(btn) {
+    btn.addEventListener('click', function(e) {
+      e.stopPropagation();
+      var open = btn.getAttribute('aria-expanded') === 'true';
+      // Close all others first
+      document.querySelectorAll('.filter-bar__dropdown-toggle[aria-expanded="true"]').forEach(function(other) {
+        if (other !== btn) other.setAttribute('aria-expanded', 'false');
+      });
+      btn.setAttribute('aria-expanded', String(!open));
+    });
+  });
+  document.addEventListener('click', function() {
+    document.querySelectorAll('.filter-bar__dropdown-toggle[aria-expanded="true"]').forEach(function(btn) {
+      btn.setAttribute('aria-expanded', 'false');
+    });
+  });
+})();
+</script>

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -85,6 +85,76 @@
   margin-top: 24px;
 }
 
+/* ── Homepage taxonomy filter bar ── */
+.right-sidebar__filters {
+  width: 100%;
+}
+.filter-bar {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.filter-bar__heading {
+  font-size: 1.3rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--card-text-color-secondary, #888);
+  margin: 0 0 2px 0;
+}
+.filter-bar__dropdown {
+  position: relative;
+}
+.filter-bar__dropdown-toggle {
+  width: 100%;
+  flex-direction: row;
+  justify-content: space-between;
+  padding: 8px 12px;
+}
+.filter-bar__chevron {
+  transition: transform 0.2s;
+  flex-shrink: 0;
+}
+.filter-bar__dropdown-toggle[aria-expanded="true"] .filter-bar__chevron {
+  transform: rotate(180deg);
+}
+.filter-bar__dropdown-menu {
+  display: none;
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  right: 0;
+  z-index: 10;
+  margin: 0;
+  padding: 4px 0;
+  list-style: none;
+  background: var(--card-background);
+  border: 1px solid var(--card-separator-color, rgba(218,218,218,0.5));
+  border-radius: 10px;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.12);
+  max-height: 240px;
+  overflow-y: auto;
+}
+.filter-bar__dropdown-toggle[aria-expanded="true"] + .filter-bar__dropdown-menu {
+  display: block;
+}
+.filter-bar__dropdown-menu li a {
+  display: block;
+  padding: 6px 14px;
+  font-size: 1.2rem;
+  font-weight: 500;
+  color: var(--card-text-color-secondary, #555);
+  text-decoration: none;
+  transition: color 0.15s, background 0.15s;
+}
+.filter-bar__dropdown-menu li a:hover {
+  color: var(--accent-color);
+  background: rgba(52, 73, 94, 0.04);
+}
+[data-scheme="dark"] .filter-bar__dropdown-menu li a:hover {
+  background: rgba(255, 255, 255, 0.06);
+}
+
 /* ── Action bar: 3-row layout, each button separate ── */
 .action-bar {
   display: flex;

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -95,12 +95,10 @@
   gap: 8px;
 }
 .filter-bar__heading {
-  font-size: 1.3rem;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: var(--card-text-color-secondary, #888);
-  margin: 0 0 2px 0;
+  font-size: 1.6rem;
+  font-weight: inherit;
+  color: var(--accent-color);
+  margin: 0 0 4px 0;
 }
 .filter-bar__dropdown {
   position: relative;


### PR DESCRIPTION
## Summary
- Add dropdown filters for Tags, Labs, and Authors on the homepage right sidebar
- "Filter posts by..." heading label above the dropdowns
- Styled to match the action-bar buttons (same border, radius, hover states)
- Opening one dropdown closes the others; clicking outside closes all

## Test plan
- [ ] Verify all three dropdowns appear on the homepage sidebar
- [ ] Clicking a dropdown reveals taxonomy terms; clicking a term navigates to its page
- [ ] Only one dropdown open at a time
- [ ] Dark mode styling works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)