### PR TITLE
Remove comments from non-blog pages and update forum links

### DIFF
--- a/content/page/forum/index.md
+++ b/content/page/forum/index.md
@@ -8,11 +8,15 @@ url: "/forum/"
 
 Join the conversation on GitHub Discussions:
 
-- **[General Discussion](https://github.com/genomicsxai/genomicsxai.github.io/discussions/categories/general)** - General topics and announcements  
-- **[Methods](https://github.com/genomicsxai/genomicsxai.github.io/discussions/categories/methods)** - Discussion about methods and techniques  
-- **[Post Discussions](https://github.com/genomicsxai/genomicsxai.github.io/discussions/categories/post-discussions)** - Discussions about published posts  
-- **[Calls for Posts](https://github.com/genomicsxai/genomicsxai.github.io/discussions/categories/calls-for-papers)** - Open calls and opportunities  
+- **[Announcements](https://github.com/genomicsxai/genomicsxai.github.io/discussions/categories/announcements)** — Official updates and news from the editorial team
+- **[Calls for Posts](https://github.com/genomicsxai/genomicsxai.github.io/discussions/categories/calls-for-posts)** — Open calls for blog post contributions
+- **[General](https://github.com/genomicsxai/genomicsxai.github.io/discussions/categories/general)** — General topics and open-ended conversation
+- **[Ideas](https://github.com/genomicsxai/genomicsxai.github.io/discussions/categories/ideas)** — Propose ideas for posts, tools, or the platform
+- **[Methods](https://github.com/genomicsxai/genomicsxai.github.io/discussions/categories/methods)** — Discussion about methods and techniques
+- **[Polls](https://github.com/genomicsxai/genomicsxai.github.io/discussions/categories/polls)** — Community polls and surveys
+- **[Post Discussions](https://github.com/genomicsxai/genomicsxai.github.io/discussions/categories/post-discussions)** — Discussions linked to published blog posts
+- **[Q&A](https://github.com/genomicsxai/genomicsxai.github.io/discussions/categories/q-a)** — Ask and answer questions
 
 ---
 
-**Note**: Each blog post also has a dedicated discussion thread. Look for the "Discuss this post" link on individual posts.
+**Note**: Each blog post also has a dedicated discussion thread. Look for the "Like" and "Comment" buttons on individual posts.

--- a/layouts/single.html
+++ b/layouts/single.html
@@ -1,0 +1,38 @@
+{{ define "body-class" }}
+    article-page
+    {{- $HasWidgetNotTOC := false -}}
+    {{- $TOCWidgetEnabled := false -}}
+    {{- range .Site.Params.widgets.page -}}
+        {{- if ne .type "toc" -}}
+            {{ $HasWidgetNotTOC = true -}}
+        {{- else -}}
+            {{ $TOCWidgetEnabled = true -}}
+        {{- end -}}
+    {{- end -}}
+
+    {{- $TOCManuallyDisabled := eq .Params.toc false -}}
+    {{- $TOCEnabled := and (not $TOCManuallyDisabled) $TOCWidgetEnabled -}}
+    {{- $hasTOC := ge (len .TableOfContents) 100 -}}
+    {{- .Scratch.Set "TOCEnabled" (and $TOCEnabled $hasTOC) -}}
+
+    {{- .Scratch.Set "hasWidget" (or $HasWidgetNotTOC (and $TOCEnabled $hasTOC)) -}}
+{{ end }}
+
+{{ define "main" }}
+    {{ partial "article/article.html" . }}
+
+    {{ if .Params.links }}
+        {{ partial "article/components/links" . }}
+    {{ end }}
+
+    {{ partial "article/components/related-content" . }}
+
+    {{ partialCached "footer/footer" . }}
+
+    {{ partialCached "article/components/photoswipe" . }}
+    {{ partial "article/components/mermaid" . }}
+{{ end }}
+
+{{ define "right-sidebar" }}
+    {{ if .Scratch.Get "hasWidget" }}{{ partial "sidebar/right.html" (dict "Context" . "Scope" "page") }}{{ end}}
+{{ end }}


### PR DESCRIPTION
## Summary
- Remove Giscus comments widget from all pages except blog posts (override theme `single.html`)
- Update forum page with all 8 GitHub Discussion categories and correct URLs

## Test plan
- [ ] Verify comments section still appears on blog posts (e.g. `/blogs/2026-002/`)
- [ ] Verify no comments section on static pages (forum, policies, editorial board, etc.)
- [ ] Verify all 8 forum category links resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)