### PR TITLE
Add view counts to sidebar and comments section

### DIFF
--- a/layouts/partials/article-comments.html
+++ b/layouts/partials/article-comments.html
@@ -25,6 +25,8 @@
     {{- end -}}
     <span class="article-comments__sep">·</span>
     <a href="/submission-guidelines/#getting-notified-of-comments-and-likes" class="article-comments__author-notify link">Authors: get notified</a>
+    <span class="article-comments__sep gc-views-sep" style="display:none">·</span>
+    <span class="article-comments__views gc-views-full" style="display:none"></span>
   </div>
   {{ if $hasGiscus }}
   <p class="article-comments__hint">Add your reaction or comment below.</p>

--- a/layouts/partials/article-meta.html
+++ b/layouts/partials/article-meta.html
@@ -17,18 +17,24 @@
   {{ if $showReadingTime }}
   <time class="article-meta__reading" datetime="PT{{ .ReadingTime }}M">{{ T "article.readingTime" .ReadingTime }}</time>
   {{ end }}
-  <span class="article-meta__sep article-meta__sep--views" style="display:none"> · </span>
-  <span class="article-meta__views" id="gc-views" style="display:none"></span>
+  <span class="article-meta__sep gc-views-sep" style="display:none"> · </span>
+  <span class="article-meta__views gc-views-full" style="display:none"></span>
   <script>
     fetch('https://{{ .Site.Params.goatCounterCode }}.goatcounter.com/counter/' + encodeURIComponent(window.location.pathname) + '.json')
       .then(function(r){ return r.json(); })
       .then(function(d){
-        if (d.count && d.count !== '0') {
-          var el = document.getElementById('gc-views');
-          el.textContent = d.count + ' views';
-          el.style.display = '';
-          var sep = document.querySelector('.article-meta__sep--views');
-          if (sep) sep.style.display = '';
+        if (!d.count) return;
+        document.querySelectorAll('.gc-views-num').forEach(function(el){
+          el.textContent = d.count;
+        });
+        if (d.count !== '0') {
+          document.querySelectorAll('.gc-views-full').forEach(function(el){
+            el.textContent = d.count + ' views';
+            el.style.display = '';
+          });
+          document.querySelectorAll('.gc-views-sep').forEach(function(el){
+            el.style.display = '';
+          });
         }
       })
       .catch(function(){});

--- a/layouts/partials/widget/post-actions.html
+++ b/layouts/partials/widget/post-actions.html
@@ -54,6 +54,11 @@
       <span class="action-bar__label">Comment</span>
       <span class="action-bar__count js-comment-count">{{ $comments }}</span>
     </a>
+    <div class="action-bar__btn action-bar__btn--static" aria-label="Views" title="Views">
+      <span class="action-bar__icon" aria-hidden="true">👁</span>
+      <span class="action-bar__label">Views</span>
+      <span class="action-bar__count gc-views-num">0</span>
+    </div>
   </div>
   {{/* Row 2: Cite + BibTeX + RIS */}}
   <div class="action-bar__row">

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -3,6 +3,11 @@
   display: flex !important;
 }
 
+/* GoatCounter view counter: non-interactive static button in the sidebar action bar */
+.action-bar__btn--static {
+  cursor: default;
+}
+
 /* ── Scroll TOC: full list, active section highlighted on scroll ── */
 .scroll-toc {
   padding: 0;


### PR DESCRIPTION
## Summary
Adds view count displays in three locations on each article page:
- Sidebar action bar (next to Like/Comment)
- Comments actions row (near reactions / "Authors: get notified")
- Article meta bar (top; refactored to share classes with the others)

A single GoatCounter fetch now populates all three locations via shared
`.gc-views-full` / `.gc-views-num` / `.gc-views-sep` classes.

Closes #27

## Test plan
- [ ] View count appears in meta bar (top of article)
- [ ] View count appears in sidebar action bar as a non-clickable button
- [ ] View count appears next to "Authors: get notified" in the comments row
- [ ] All three locations show the same number
- [ ] Counts hide entirely when a page has zero views (sidebar shows "0")

🤖 Generated with [Claude Code](https://claude.com/claude-code)