### PR TITLE
ci: allow data/ in PR preview safety allowlist

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -10,6 +10,7 @@ on:
       - 'content/blogs/**'
       - 'layouts/**'
       - 'static/**'
+      - 'data/**'
       - 'docs/**'
       - '.gitignore'
 
@@ -22,7 +23,7 @@ jobs:
 
     steps:
       # Safety check: only proceed if the PR exclusively touches known-safe paths.
-      # Allowed: content/blogs/, layouts/, static/, docs/, .gitignore
+      # Allowed: content/blogs/, layouts/, static/, data/, docs/, .gitignore
       # Blocked: .github/workflows/, .github/scripts/, config.toml, and anything else.
       # Note: pull_request_target always runs the base repo's workflow, so workflow
       # files in the PR cannot hijack this job. We still block them as a belt-and-
@@ -41,6 +42,7 @@ jobs:
             | grep -v '^content/blogs/' \
             | grep -v '^layouts/' \
             | grep -v '^static/' \
+            | grep -v '^data/' \
             | grep -v '^docs/' \
             | grep -v '^\.gitignore$' \
             || true)
@@ -68,6 +70,7 @@ jobs:
             - `content/blogs/` — blog post content
             - `layouts/` — Hugo templates
             - `static/` — static assets
+            - `data/` — Hugo data files (YAML/JSON used by templates)
             - `docs/` — documentation
             - `.gitignore`
 


### PR DESCRIPTION
## Summary
- Adds \`data/\` to the PR preview workflow's path filter and safety check
- Adds it to the \"Preview Deployment Skipped\" comment template so the message stays accurate

## Why
Hugo data files (e.g. \`data/disciplines.yaml\`) drive widgets and template partials. Previous allowlist blocked any PR that touched \`data/\`, so preview deploys silently skipped — PR #29's discipline-filter feature didn't surface in the preview at all because the new \`data/disciplines.yaml\` triggered the safety check.

Same shape as the earlier allowlist expansion for \`layouts/static/docs/\`.

## Test plan
- [ ] CI on this PR runs (this PR only touches \`.github/workflows/\` so the preview workflow won't try to deploy itself, which is the intended behavior)
- [ ] After merge, re-trigger PR #29 (push or empty commit) and confirm preview deploys with the new discipline filter visible