### PR TITLE
ci: allow all of content/ in PR preview safety allowlist

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -7,7 +7,7 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened]
     paths:
-      - 'content/blogs/**'
+      - 'content/**'
       - 'layouts/**'
       - 'static/**'
       - 'data/**'
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       # Safety check: only proceed if the PR exclusively touches known-safe paths.
-      # Allowed: content/blogs/, layouts/, static/, data/, docs/, .gitignore
+      # Allowed: content/, layouts/, static/, data/, docs/, .gitignore
       # Blocked: .github/workflows/, .github/scripts/, config.toml, and anything else.
       # Note: pull_request_target always runs the base repo's workflow, so workflow
       # files in the PR cannot hijack this job. We still block them as a belt-and-
@@ -39,7 +39,7 @@ jobs:
 
           # Known-safe path prefixes / exact files
           UNSAFE=$(echo "$FILES" | grep -v '^[[:space:]]*$' \
-            | grep -v '^content/blogs/' \
+            | grep -v '^content/' \
             | grep -v '^layouts/' \
             | grep -v '^static/' \
             | grep -v '^data/' \
@@ -67,7 +67,7 @@ jobs:
 
             This PR modifies files outside the allowed safe paths. Preview deployment is only available for PRs that exclusively touch:
 
-            - `content/blogs/` — blog post content
+            - `content/` — blog posts and static pages
             - `layouts/` — Hugo templates
             - `static/` — static assets
             - `data/` — Hugo data files (YAML/JSON used by templates)


### PR DESCRIPTION
## Summary
- Broadens \`content/blogs/**\` to \`content/**\` in both the path filter and safety check
- Updates the \"Preview Deployment Skipped\" comment template to match

## Why
\`content/page/\` holds the static pages (editorial-board, editorial-review, forum, policies, submission-guidelines, archives, newsletter). They're plain markdown rendered by Hugo, no different from \`content/blogs/\` from a build-safety perspective. The previous narrower allowlist silently skipped preview deploys for any edit under \`content/page/\` — surfaced when a recent push to PR #29 updated the editorial-board / editorial-review pages and the changes never appeared in the preview.

Same shape as the earlier expansions for \`layouts/static/docs/\` and \`data/\`.

## Test plan
- [ ] After merge, push a tiny commit to PR #29 and confirm the editorial-board page renders the new \"discipline tag\" requirement in the deployed preview