### PR TITLE
Backfill DOI metadata for existing blog posts

### DIFF
--- a/content/blogs/2026-001/index.md
+++ b/content/blogs/2026-001/index.md
@@ -20,7 +20,7 @@ scope: ["insights"]
 audience: ["within-field", "general"]
 labs: ["Genomics x AI"]
 
-status: "submitted"
+status: "accepted"
 revision: 1
 
 date_submitted: 2026-02-19
@@ -28,10 +28,13 @@ date_accepted: 2026-02-19
 date: 2026-02-19
 
 doi: ""
+zenodo_url: ""
 revision_history:
   - version: 1
     date: 2026-02-19
     notes: "Initial welcome post"
+    doi: ""
+    zenodo_url: ""
 ---
 
 ![Genomics × AI](genomics_x_ai_title.png "width=400")

--- a/content/blogs/2026-002/index.md
+++ b/content/blogs/2026-002/index.md
@@ -32,18 +32,21 @@ scope: ["insights"]
 audience: ["general"]
 labs: ["Koo lab"]
 
-status: "submitted"
+status: "accepted"
 revision: 1
 
 date_submitted: 2026-02-20
-date_accepted:
+date_accepted: 2026-02-20
 date: 2026-02-20
 
 doi: ""
+zenodo_url: ""
 revision_history:
   - version: 1
     date: 2026-02-20
     notes: "Initial submission"
+    doi: ""
+    zenodo_url: ""
 ---
 
 {{< summary >}}

--- a/content/blogs/2026-003/index.md
+++ b/content/blogs/2026-003/index.md
@@ -36,18 +36,21 @@ scope: ["tutorials"]
 audience: ["general"]
 labs: ["Koo lab","Kundaje lab"]
 
-status: "submitted"
+status: "accepted"
 revision: 1
 
 date_submitted: 2026-02-25
-date_accepted:
+date_accepted: 2026-02-25
 date: 2026-02-25
 
 doi: ""
+zenodo_url: ""
 revision_history:
   - version: 1
     date: 2026-02-25
     notes: "Initial submission"
+    doi: ""
+    zenodo_url: ""
 ---
 
 {{< summary >}}

--- a/content/blogs/2026-004/index.md
+++ b/content/blogs/2026-004/index.md
@@ -37,18 +37,21 @@ scope: ["tutorials"]
 audience: ["general"]
 labs: ["Kundaje lab"]
 
-status: "submitted"
+status: "accepted"
 revision: 1
 
 date_submitted: 2026-03-10
-date_accepted:
+date_accepted: 2026-03-10
 date: 2026-03-10
 
 doi: ""
+zenodo_url: ""
 revision_history:
   - version: 1
     date: 2026-03-10
     notes: "Initial submission"
+    doi: ""
+    zenodo_url: ""
 ---
 
 {{< summary >}}

--- a/content/blogs/2026-005/index.md
+++ b/content/blogs/2026-005/index.md
@@ -27,21 +27,26 @@ scope: ["insights"]
 audience: ["general"]
 labs: ["Kundaje lab", "Mostafavi lab"]
 
-status: "submitted"
+status: "accepted"
 revision: 2
 
 date_submitted: 2026-04-12
-date_accepted:
+date_accepted: 2026-04-15
 date: 2026-04-15
 
 doi: ""
+zenodo_url: ""
 revision_history:
   - version: 1
     date: 2026-04-12
     notes: "Initial benchmark draft"
+    doi: ""
+    zenodo_url: ""
   - version: 2
     date: 2026-04-15
     notes: "Updated with H100 results"
+    doi: ""
+    zenodo_url: ""
 ---
 
 {{< summary >}}


### PR DESCRIPTION
## Summary
- mark existing published blog posts as accepted for DOI backfill
- add empty Zenodo URL fields to match the DOI metadata schema
- preserve current revision numbers, including 2026-005 at revision 2

## Verification
- hugo --minify