### PR TITLE
Make discussion token optional during deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -116,8 +116,7 @@ jobs:
             exit 1
           fi
           if [ -z "$GH_DISCUSSIONS_TOKEN" ]; then
-            echo "GH_DISCUSSIONS_TOKEN is required for production discussion sync."
-            exit 1
+            echo "GH_DISCUSSIONS_TOKEN is not configured; discussion sync will be skipped."
           fi
           if [ "${{ steps.changed_blogs.outputs.accepted_count }}" != "0" ]; then
             if [ -z "$ZENODO_API_TOKEN" ]; then


### PR DESCRIPTION
## Summary
- keep production deploy blocked when GH_PAGES_TOKEN is missing
- keep DOI sync secrets required when accepted blog posts changed
- allow deploys to continue without GH_DISCUSSIONS_TOKEN because discussion sync steps are already conditional

## Context
The DOI backfill deploy failed before Zenodo sync because GH_DISCUSSIONS_TOKEN is not configured, while ZENODO_API_TOKEN and GH_CONTENTS_WRITE_TOKEN are configured.