### PR TITLE
Match citation text typography

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -809,7 +809,9 @@ article img {
 .citation-box__text {
   margin: 0 0 1.25em 0;
   color: var(--card-text-color-main, #000);
-  font-size: 1.2em;
+  font-family: inherit;
+  font-size: inherit;
+  line-height: inherit;
 }
 
 .citation-box__versions {


### PR DESCRIPTION
## Summary
- make the citation sentence inherit surrounding font family, size, and line height
- keeps the simplified DOI display from the prior PR

## Verification
- hugo --minify
- checked generated HTML/CSS for /blogs/2026-001/