### PR TITLE
Add DOI workflow validation post

### DIFF
--- a/content/blogs/2026-006/index.md
+++ b/content/blogs/2026-006/index.md
@@ -1,0 +1,45 @@
+---
+post_id: "2026-006"
+title: "DOI Workflow Validation Post"
+authors: ["Genomics X AI Editors"]
+
+authors_display:
+  - name: "Genomics X AI Editors"
+    affiliation: "Genomics x AI"
+    orcid: ""
+
+editor: "Genomics X AI Editors"
+
+tags: ["workflow", "doi", "testing"]
+categories: ["Announcement"]
+
+scope: ["insights"]
+audience: ["general"]
+labs: ["Genomics x AI"]
+
+status: "accepted"
+revision: 1
+
+date_submitted: 2026-05-18
+date_accepted: 2026-05-18
+date: 2026-05-18
+
+doi: ""
+zenodo_url: ""
+revision_history:
+  - version: 1
+    date: 2026-05-18
+    notes: "Initial workflow validation post"
+    doi: ""
+    zenodo_url: ""
+---
+
+{{< summary >}}
+This short post validates the Genomics x AI production DOI workflow for newly accepted blog posts.
+{{< /summary >}}
+
+This post is an operational workflow validation article for the Genomics x AI site.
+
+It confirms that a newly accepted blog post can move through the production publishing path, receive Zenodo DOI metadata, and render that DOI on the public blog page.
+
+After validation is complete, the site maintainers may hide this article from normal website navigation while preserving the permanent Zenodo record created by the test.


### PR DESCRIPTION
## Summary
- add a short accepted workflow validation post as content/blogs/2026-006
- intended to trigger the production Zenodo DOI workflow for a newly accepted post

## Verification
- hugo --minify

## Follow-up
- after DOI metadata is confirmed on the site, hide the validation post from normal navigation.