### PR TITLE
Hide DOI workflow validation post

### DIFF
--- a/content/blogs/2026-006/index.md
+++ b/content/blogs/2026-006/index.md
@@ -1,6 +1,7 @@
 ---
 post_id: "2026-006"
 title: "DOI Workflow Validation Post"
+draft: true
 authors: ["Genomics X AI Editors"]
 
 authors_display:
@@ -17,7 +18,7 @@ scope: ["insights"]
 audience: ["general"]
 labs: ["Genomics x AI"]
 
-status: "accepted"
+status: "withdrawn"
 revision: 1
 
 date_submitted: 2026-05-18


### PR DESCRIPTION
## Summary
- mark the DOI workflow validation post as draft
- move its editorial status from accepted to withdrawn so it does not trigger future DOI sync

## Verification
- hugo --minify --destination /tmp/genomicsxai-hugo-hide-check
- confirmed /blogs/2026-006/index.html is absent from a clean build