### PR TITLE
Temporarily unhide DOI validation post

### DIFF
--- a/content/blogs/2026-006/index.md
+++ b/content/blogs/2026-006/index.md
@@ -1,7 +1,6 @@
 ---
 post_id: "2026-006"
 title: "DOI Workflow Validation Post"
-draft: true
 authors: ["Genomics X AI Editors"]
 
 authors_display:
@@ -18,7 +17,7 @@ scope: ["insights"]
 audience: ["general"]
 labs: ["Genomics x AI"]
 
-status: "withdrawn"
+status: "accepted"
 revision: 1
 
 date_submitted: 2026-05-18


### PR DESCRIPTION
## Summary
- temporarily publish the DOI workflow validation post again for visual verification
- restores status: accepted and removes draft: true
- existing data/zenodo.json already has revision 1 DOI metadata, so no duplicate DOI should be minted

## Verification
- hugo --minify