### PR TITLE
Link DOI URL in citation section

### DIFF
--- a/layouts/partials/citation.html
+++ b/layouts/partials/citation.html
@@ -12,7 +12,10 @@
     <em>{{ $blogName }}</em>,
     {{ $fullDate }}.
     <a href="{{ $url }}">{{ $url }}</a>.
-    {{ with $citationData.doi }} DOI: {{ . }}.{{ end }}
+    {{ with $citationData.doi }}
+      {{- $doiURL := printf "https://doi.org/%s" . -}}
+      <a href="{{ $doiURL }}" target="_blank" rel="noopener">{{ $doiURL }}</a>.
+    {{- end }}
   </p>
 </div>
 <script src="{{ "js/citation.js" | relURL }}" defer></script>


### PR DESCRIPTION
## Summary
- render the visible citation section DOI as a full https://doi.org/... link
- keep Cite/Bib/RIS export data unchanged

## Verification
- hugo --minify
- checked generated /blogs/2026-004/ HTML contains https://doi.org/10.5281/zenodo.20272905 in the citation section