### PR TITLE
Use Zenodo version DOI in citation metadata

### DIFF
--- a/layouts/partials/helper/citation-data.html
+++ b/layouts/partials/helper/citation-data.html
@@ -19,13 +19,7 @@
 {{- $fullDate := $page.Date | dateFormat "2 January 2006" -}}
 {{- $dateISO := $page.Date | dateFormat "2006-01-02" -}}
 {{- $citeURL := $page.Permalink | absURL -}}
-{{- $conceptrecid := $zenodoEntry.conceptrecid | default "" -}}
-{{- $doi := "" -}}
-{{- if $conceptrecid -}}
-  {{- $doi = printf "10.5281/zenodo.%v" $conceptrecid -}}
-{{- else -}}
-  {{- $doi = $zenodoEntry.current_doi | default ($page.Params.doi | default "") -}}
-{{- end -}}
+{{- $doi := $zenodoEntry.current_doi | default ($page.Params.doi | default "") -}}
 {{- $citationPlain := printf "%s. \"%s.\" %s, %s. %s" $authorStr $page.Title $blogName $fullDate $citeURL -}}
 {{- if $doi -}}
   {{- $citationPlain = printf "%s. https://doi.org/%s" $citationPlain $doi -}}

--- a/layouts/partials/jsonld.html
+++ b/layouts/partials/jsonld.html
@@ -6,13 +6,7 @@
     {{- $zenodoEntry = . -}}
   {{- end -}}
 {{- end -}}
-{{- $conceptrecid := $zenodoEntry.conceptrecid | default "" -}}
-{{- $doi := "" -}}
-{{- if $conceptrecid -}}
-  {{- $doi = printf "10.5281/zenodo.%v" $conceptrecid -}}
-{{- else -}}
-  {{- $doi = $zenodoEntry.current_doi | default (.Params.doi | default "") -}}
-{{- end -}}
+{{- $doi := $zenodoEntry.current_doi | default (.Params.doi | default "") -}}
 {
   "@context": "https://schema.org",
   "@type": "BlogPosting",


### PR DESCRIPTION
## Summary
- use the Zenodo current/version DOI in citation data and JSON-LD
- keeps the visible citation section rendering DOI as a full https://doi.org/... URL
- leaves BibTeX/RIS DOI fields as bare DOI values, which is the standard format

## Verification
- hugo --minify
- checked generated 2026-005 HTML: copy citation, Bib/RIS payload, bottom citation link, and JSON-LD all use 10.5281/zenodo.20272910