### PR TITLE
Show post actions on short blog posts

### DIFF
--- a/layouts/blogs/single.html
+++ b/layouts/blogs/single.html
@@ -7,8 +7,9 @@
     {{- $TOCManuallyDisabled := eq .Params.toc false -}}
     {{- $TOCEnabled := and (not $TOCManuallyDisabled) $TOCWidgetEnabled -}}
     {{- $hasTOC := gt (len .TableOfContents) 50 -}}
+    {{- $hasPostActions := eq .Section "blogs" -}}
     {{- .Scratch.Set "TOCEnabled" (and $TOCEnabled $hasTOC) -}}
-    {{- .Scratch.Set "hasWidget" (and $TOCEnabled $hasTOC) -}}
+    {{- .Scratch.Set "hasWidget" (or (and $TOCEnabled $hasTOC) $hasPostActions) -}}
 {{ end }}
 
 {{ define "main" }}


### PR DESCRIPTION
## Summary
- render the right-side post actions for all blog posts, even when a post is too short to have a table of contents
- keeps TOC rendering conditional on actual TOC content

## Verification
- hugo --minify
- checked generated /blogs/2026-006/ HTML contains right-sidebar actions and the Cite button