### PR TITLE
Test Zenodo new-version DOI for validation post

### DIFF
--- a/content/blogs/2026-006/index.md
+++ b/content/blogs/2026-006/index.md
@@ -18,7 +18,7 @@ audience: ["general"]
 labs: ["Genomics x AI"]
 
 status: "accepted"
-revision: 1
+revision: 2
 
 date_submitted: 2026-05-18
 date_accepted: 2026-05-18
@@ -32,6 +32,11 @@ revision_history:
     notes: "Initial workflow validation post"
     doi: ""
     zenodo_url: ""
+  - version: 2
+    date: 2026-05-18
+    notes: "Second workflow validation revision"
+    doi: ""
+    zenodo_url: ""
 ---
 
 {{< summary >}}
@@ -41,5 +46,7 @@ This short post validates the Genomics x AI production DOI workflow for newly ac
 This post is an operational workflow validation article for the Genomics x AI site.
 
 It confirms that a newly accepted blog post can move through the production publishing path, receive Zenodo DOI metadata, and render that DOI on the public blog page.
+
+Revision 2 adds a small content change to validate Zenodo new-version DOI creation for an existing blog post record.
 
 After validation is complete, the site maintainers may hide this article from normal website navigation while preserving the permanent Zenodo record created by the test.


### PR DESCRIPTION
## Summary
- bump only the fake DOI workflow validation post, content/blogs/2026-006, from revision 1 to revision 2
- add a small content sentence and revision_history entry to trigger Zenodo new-version DOI creation
- do not touch real blog posts

## Verification
- hugo --minify

## Expected result
The main deploy should update data/zenodo.json with a new revision 2 DOI for 2026-006 under the same Zenodo concept record.