### PR TITLE
Clarify DOI workflow documentation

### DIFF
--- a/.github/workflows/test-publish.yml
+++ b/.github/workflows/test-publish.yml
@@ -1,17 +1,6 @@
 name: test-publish
 
 on:
-  push:
-    branches:
-      - issue-24-add-doi
-    paths:
-      - 'content/blogs/**'
-      - 'data/zenodo.json'
-      - 'layouts/**'
-      - 'config.toml'
-      - 'config/**'
-      - '.github/scripts/**'
-      - '.github/workflows/test-publish.yml'
   workflow_dispatch:
     inputs:
       blog_post_paths:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 [website](https://genomicsxai.github.io/)
 
+## Production DOI Workflow
+
+The `Deploy Hugo Site` workflow syncs Zenodo DOI metadata for accepted blog posts changed on `main` before building the public site. It publishes Zenodo records when `ZENODO_API_TOKEN` is configured, commits the resulting metadata to `data/zenodo.json`, and renders the current version DOI from that data.
+
+To publish a new version of a post, update the post content and increment its `revision` frontmatter. Zenodo creates a new numeric version DOI under the same concept record, for example `https://doi.org/10.5281/zenodo.20277035`; it does not create `v2` or `v3` DOI URL suffixes. Frontmatter `doi` and `zenodo_url` values are still supported as manual fallback fields, but maintainers should normally leave them blank and let `data/zenodo.json` be the source of truth.
+
+The archived DOI workflow validation post confirmed production v1/v2/v3 versioning and is now withdrawn from the public site.
+
 ## Manual Test Publish
 
 Use the `Test Publish Pipeline` GitHub Actions workflow to exercise the production publish path on a branch without touching the live site.

--- a/docs/BLOG_SPEC.md
+++ b/docs/BLOG_SPEC.md
@@ -230,22 +230,22 @@ GitHub Discussions, categories:
 - BibTeX download (e.g. `static/bib/<post_id>.bib` when generated).  
 - RIS download (e.g. `static/bib/<post_id>.ris` when generated).  
 - Copy citation button.  
-- DOI link when available.
-- Zenodo link when available.
-- DOI version history from `revision_history` when revision entries include DOI metadata.
+- Current version DOI link when available, rendered as a full `https://doi.org/...` URL.
 
 Rendered via Hugo partial (e.g. `citation.html`).
 
-When the repository secret `ZENODO_API_TOKEN` is configured, the deploy workflow can mint/publish Zenodo records for accepted posts changed in the current push and store the resulting DOI metadata in `data/zenodo.json`. Frontmatter DOI fields remain valid as a manual override/fallback.
+When the repository secret `ZENODO_API_TOKEN` is configured, the deploy workflow mints/publishes Zenodo records for accepted posts changed in the current push and stores the resulting DOI metadata in `data/zenodo.json`. Frontmatter DOI fields remain valid as a manual override/fallback. BibTeX and RIS exports use standard bare DOI values, while visible citations use full DOI URLs.
 
 ### 10.2 Machine-readable metadata
 
 - JSON-LD `BlogPosting` schema.  
 - Generated via Hugo partial (e.g. `jsonld.html`).
 
-### 10.3 DOI (optional, Phase 2)
+### 10.3 DOI
 
-- GitHub Release on acceptance; archive via Zenodo; store DOI in frontmatter.
+- Accepted blog posts changed on `main` are archived through Zenodo by `deploy.yml`.
+- New post revisions are published as Zenodo new versions under the same concept record.
+- DOI metadata is stored in `data/zenodo.json`; frontmatter `doi` and `zenodo_url` fields are fallback/manual override fields.
 
 ---
 


### PR DESCRIPTION
## Summary
- Document the production Zenodo DOI workflow and version DOI behavior
- Align BLOG_SPEC citation/DOI wording with current rendering and BibTeX/RIS behavior
- Make test-publish manual-only by removing the stale issue-24-add-doi push trigger

## Verification
- hugo --minify