### PR TITLE
ci: use built-in GITHUB_TOKEN instead of personal PATs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,8 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
+      discussions: write
     environment:
       name: github-pages
 
@@ -23,7 +24,6 @@ jobs:
       # 1. Checkout the repo (with submodules for theme)
       - uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GH_CONTENTS_WRITE_TOKEN || github.token }}
           submodules: true
           fetch-depth: 0
 
@@ -32,38 +32,18 @@ jobs:
         with:
           extended: true
 
-      - name: Detect available write tokens
-        id: token_flags
-        env:
-          GH_PAGES_TOKEN: ${{ secrets.GH_PAGES_TOKEN }}
-          GH_DISCUSSIONS_TOKEN: ${{ secrets.GH_DISCUSSIONS_TOKEN }}
-        shell: bash
-        run: |
-          if [ -n "$GH_PAGES_TOKEN" ]; then
-            echo "has_pages_token=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_pages_token=false" >> "$GITHUB_OUTPUT"
-          fi
-          if [ -n "$GH_DISCUSSIONS_TOKEN" ]; then
-            echo "has_discussions_token=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_discussions_token=false" >> "$GITHUB_OUTPUT"
-          fi
-
       # 2.4. Ensure a GitHub Discussion exists for each blog post (for Giscus likes/comments)
       - name: Ensure blog discussions
-        if: steps.token_flags.outputs.has_discussions_token == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GH_DISCUSSIONS_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           chmod +x .github/scripts/ensure-blog-discussions.sh
           ./.github/scripts/ensure-blog-discussions.sh
 
       # 2.4b. Export discussion URLs so "Discuss this post" and like/comment link to the right thread
       - name: Export blog discussion URLs
-        if: steps.token_flags.outputs.has_discussions_token == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GH_DISCUSSIONS_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           chmod +x .github/scripts/export-blog-discussion-urls.sh
           ./.github/scripts/export-blog-discussion-urls.sh
@@ -106,25 +86,11 @@ jobs:
 
       - name: Validate required publish secrets
         env:
-          GH_PAGES_TOKEN: ${{ secrets.GH_PAGES_TOKEN }}
-          GH_DISCUSSIONS_TOKEN: ${{ secrets.GH_DISCUSSIONS_TOKEN }}
-          GH_CONTENTS_WRITE_TOKEN: ${{ secrets.GH_CONTENTS_WRITE_TOKEN }}
           ZENODO_API_TOKEN: ${{ secrets.ZENODO_API_TOKEN }}
         run: |
-          if [ -z "$GH_PAGES_TOKEN" ]; then
-            echo "GH_PAGES_TOKEN is required for production deploys."
-            exit 1
-          fi
-          if [ -z "$GH_DISCUSSIONS_TOKEN" ]; then
-            echo "GH_DISCUSSIONS_TOKEN is not configured; discussion sync will be skipped."
-          fi
           if [ "${{ steps.changed_blogs.outputs.accepted_count }}" != "0" ]; then
             if [ -z "$ZENODO_API_TOKEN" ]; then
               echo "ZENODO_API_TOKEN is required when accepted blog posts changed in this deploy."
-              exit 1
-            fi
-            if [ -z "$GH_CONTENTS_WRITE_TOKEN" ]; then
-              echo "GH_CONTENTS_WRITE_TOKEN is required to commit updated data/zenodo.json."
               exit 1
             fi
           fi
@@ -142,7 +108,7 @@ jobs:
       - name: Commit Zenodo metadata
         if: steps.changed_blogs.outputs.count != '0'
         env:
-          GH_TOKEN: ${{ secrets.GH_CONTENTS_WRITE_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           if [ -z "$(git status --porcelain -- data/zenodo.json)" ]; then
             echo "No Zenodo metadata changes to commit."
@@ -175,7 +141,7 @@ jobs:
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v4
         with:
-          github_token: ${{ secrets.GH_PAGES_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./public
           publish_branch: gh-pages
           # keep_files: true preserves the previews/ subdirectory across deploys

--- a/.github/workflows/pr-preview-cleanup.yml
+++ b/.github/workflows/pr-preview-cleanup.yml
@@ -12,37 +12,17 @@ jobs:
   cleanup:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
+      contents: write
+      pull-requests: write
 
     steps:
-      - name: Detect available write tokens
-        id: token_flags
-        env:
-          GH_PAGES_TOKEN: ${{ secrets.GH_PAGES_TOKEN }}
-          GH_PR_COMMENT_TOKEN: ${{ secrets.GH_PR_COMMENT_TOKEN }}
-        shell: bash
-        run: |
-          if [ -n "$GH_PAGES_TOKEN" ]; then
-            echo "has_pages_token=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_pages_token=false" >> "$GITHUB_OUTPUT"
-          fi
-          if [ -n "$GH_PR_COMMENT_TOKEN" ]; then
-            echo "has_pr_comment_token=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_pr_comment_token=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Checkout gh-pages branch
-        if: steps.token_flags.outputs.has_pages_token == 'true'
         uses: actions/checkout@v4
         with:
           ref: gh-pages
-          token: ${{ secrets.GH_PAGES_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Delete preview directory
-        if: steps.token_flags.outputs.has_pages_token == 'true'
         run: |
           PR_DIR="previews/pr-${{ github.event.number }}"
           if [ -d "$PR_DIR" ]; then
@@ -57,19 +37,12 @@ jobs:
           fi
 
       - name: Update PR comment
-        if: steps.token_flags.outputs.has_pr_comment_token == 'true'
         uses: marocchino/sticky-pull-request-comment@v2
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_PR_COMMENT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           header: preview-deployment
           message: |
             ## Preview Deployment Removed
 
             The preview for this PR has been deleted now that it is closed.
-
-      - name: Validate cleanup token availability
-        if: steps.token_flags.outputs.has_pages_token != 'true'
-        run: |
-          echo "GH_PAGES_TOKEN is required to remove PR previews from gh-pages."
-          exit 1

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -22,8 +22,8 @@ jobs:
   deploy-preview:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
+      contents: write
+      pull-requests: write
 
     steps:
       # Safety check: only proceed if the PR exclusively touches known-safe paths.
@@ -61,29 +61,11 @@ jobs:
             echo "safe=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Detect available write tokens
-        id: token_flags
-        env:
-          GH_PAGES_TOKEN: ${{ secrets.GH_PAGES_TOKEN }}
-          GH_PR_COMMENT_TOKEN: ${{ secrets.GH_PR_COMMENT_TOKEN }}
-        shell: bash
-        run: |
-          if [ -n "$GH_PAGES_TOKEN" ]; then
-            echo "has_pages_token=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_pages_token=false" >> "$GITHUB_OUTPUT"
-          fi
-          if [ -n "$GH_PR_COMMENT_TOKEN" ]; then
-            echo "has_pr_comment_token=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_pr_comment_token=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: "Comment: preview skipped (unsafe PR)"
-        if: steps.safety.outputs.safe == 'false' && steps.token_flags.outputs.has_pr_comment_token == 'true'
+        if: steps.safety.outputs.safe == 'false'
         uses: marocchino/sticky-pull-request-comment@v2
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_PR_COMMENT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           header: preview-deployment
           message: |
@@ -154,20 +136,20 @@ jobs:
                --baseURL "https://genomicsxai.github.io/previews/pr-${{ github.event.number }}/"
 
       - name: Deploy preview to gh-pages
-        if: steps.safety.outputs.safe == 'true' && steps.token_flags.outputs.has_pages_token == 'true'
+        if: steps.safety.outputs.safe == 'true'
         uses: peaceiris/actions-gh-pages@v4
         with:
-          github_token: ${{ secrets.GH_PAGES_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./public
           publish_branch: gh-pages
           destination_dir: previews/pr-${{ github.event.number }}
           keep_files: true
 
       - name: Post preview comment
-        if: steps.safety.outputs.safe == 'true' && steps.token_flags.outputs.has_pr_comment_token == 'true'
+        if: steps.safety.outputs.safe == 'true'
         uses: marocchino/sticky-pull-request-comment@v2
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_PR_COMMENT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           header: preview-deployment
           message: |
@@ -179,8 +161,3 @@ jobs:
             ${{ steps.detect.outputs.links }}
             > Not indexed by search engines and not linked from the main blog.
             > Updated automatically on each new commit. Deleted when the PR is closed.
-
-      - name: Report missing preview deploy token
-        if: steps.safety.outputs.safe == 'true' && steps.token_flags.outputs.has_pages_token != 'true'
-        run: |
-          echo "GH_PAGES_TOKEN is not configured; skipping PR preview deploy."

--- a/.github/workflows/test-publish.yml
+++ b/.github/workflows/test-publish.yml
@@ -35,13 +35,13 @@ jobs:
   test-publish:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
+      discussions: write
 
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
-          token: ${{ secrets.GH_CONTENTS_WRITE_TOKEN || github.token }}
           submodules: true
           fetch-depth: 0
 
@@ -67,24 +67,6 @@ jobs:
           echo "preview_url=${URL}" >> "$GITHUB_OUTPUT"
           echo "Using preview path ${DEST}"
 
-      - name: Detect available write tokens
-        id: token_flags
-        env:
-          GH_PAGES_TOKEN: ${{ secrets.GH_PAGES_TOKEN }}
-          GH_DISCUSSIONS_TOKEN: ${{ secrets.GH_DISCUSSIONS_TOKEN }}
-        shell: bash
-        run: |
-          if [ -n "$GH_PAGES_TOKEN" ]; then
-            echo "has_pages_token=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_pages_token=false" >> "$GITHUB_OUTPUT"
-          fi
-          if [ -n "$GH_DISCUSSIONS_TOKEN" ]; then
-            echo "has_discussions_token=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_discussions_token=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Resolve preview behavior
         id: preview_flags
         shell: bash
@@ -98,27 +80,18 @@ jobs:
           fi
 
       - name: Ensure blog discussions
-        if: steps.token_flags.outputs.has_discussions_token == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GH_DISCUSSIONS_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           chmod +x .github/scripts/ensure-blog-discussions.sh
           ./.github/scripts/ensure-blog-discussions.sh
 
       - name: Export blog discussion URLs
-        if: steps.token_flags.outputs.has_discussions_token == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GH_DISCUSSIONS_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           chmod +x .github/scripts/export-blog-discussion-urls.sh
           ./.github/scripts/export-blog-discussion-urls.sh
-
-      - name: Stub discussion data for preview
-        if: steps.token_flags.outputs.has_discussions_token != 'true'
-        run: |
-          mkdir -p data
-          echo '{}' > data/discussions.json
-          echo "GH_DISCUSSIONS_TOKEN is not configured; using empty discussions data for preview."
 
       - name: Fetch editors from GitHub team
         env:
@@ -185,21 +158,11 @@ jobs:
 
       - name: Validate required test-publish secrets
         env:
-          GH_PAGES_TOKEN: ${{ secrets.GH_PAGES_TOKEN }}
-          GH_CONTENTS_WRITE_TOKEN: ${{ secrets.GH_CONTENTS_WRITE_TOKEN }}
           ZENODO_API_TOKEN: ${{ secrets.ZENODO_API_TOKEN }}
         run: |
-          if [ "${{ steps.preview_flags.outputs.should_deploy_preview }}" = "true" ] && [ -z "$GH_PAGES_TOKEN" ]; then
-            echo "GH_PAGES_TOKEN is required when deploy_preview=true."
-            exit 1
-          fi
           if [ "${{ github.event.inputs.zenodo_dry_run || 'true' }}" != "true" ] && [ "${{ steps.changed_blogs.outputs.accepted_count }}" != "0" ]; then
             if [ -z "$ZENODO_API_TOKEN" ]; then
               echo "ZENODO_API_TOKEN is required for non-dry-run Zenodo sync."
-              exit 1
-            fi
-            if [ -z "$GH_CONTENTS_WRITE_TOKEN" ]; then
-              echo "GH_CONTENTS_WRITE_TOKEN is required to commit updated data/zenodo.json."
               exit 1
             fi
           fi
@@ -227,7 +190,7 @@ jobs:
       - name: Commit Zenodo metadata
         if: steps.changed_blogs.outputs.count != '0' && github.event.inputs.zenodo_dry_run != 'true'
         env:
-          GH_TOKEN: ${{ secrets.GH_CONTENTS_WRITE_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           if [ -z "$(git status --porcelain -- data/zenodo.json)" ]; then
             echo "No Zenodo metadata changes to commit."
@@ -263,7 +226,7 @@ jobs:
         if: steps.preview_flags.outputs.should_deploy_preview == 'true'
         uses: peaceiris/actions-gh-pages@v4
         with:
-          github_token: ${{ secrets.GH_PAGES_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./public
           publish_branch: gh-pages
           destination_dir: ${{ steps.preview.outputs.destination_dir }}

--- a/.github/workflows/zenodo-sync.yml
+++ b/.github/workflows/zenodo-sync.yml
@@ -21,12 +21,11 @@ jobs:
   zenodo-sync:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
 
     steps:
       - uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GH_CONTENTS_WRITE_TOKEN || github.token }}
           submodules: true
           fetch-depth: 0
 
@@ -56,14 +55,9 @@ jobs:
       - name: Validate required Zenodo sync secrets
         env:
           ZENODO_API_TOKEN: ${{ secrets.ZENODO_API_TOKEN }}
-          GH_CONTENTS_WRITE_TOKEN: ${{ secrets.GH_CONTENTS_WRITE_TOKEN }}
         run: |
           if [ -z "$ZENODO_API_TOKEN" ]; then
             echo "ZENODO_API_TOKEN is not configured."
-            exit 1
-          fi
-          if [ "${{ github.event.inputs.zenodo_dry_run }}" != "true" ] && [ -z "$GH_CONTENTS_WRITE_TOKEN" ]; then
-            echo "GH_CONTENTS_WRITE_TOKEN is required to commit updated data/zenodo.json."
             exit 1
           fi
 
@@ -91,7 +85,7 @@ jobs:
       - name: Commit Zenodo metadata
         if: github.event.inputs.zenodo_dry_run != 'true'
         env:
-          GH_TOKEN: ${{ secrets.GH_CONTENTS_WRITE_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           if [ -z "$(git status --porcelain -- data/zenodo.json)" ]; then
             echo "No Zenodo metadata changes to commit."


### PR DESCRIPTION
## Summary

Removes CI's dependence on per-editor personal access tokens so workflows don't break when an editor leaves the org. All GitHub write operations now use the workflow's built-in `GITHUB_TOKEN`, scoped via per-job `permissions:` blocks.

## Changes

| Workflow | Now uses | Permissions |
|---|---|---|
| `deploy.yml` | `GITHUB_TOKEN` for gh-pages deploy, discussions, Zenodo commit | `contents: write`, `discussions: write` |
| `pr-preview.yml` / `pr-preview-cleanup.yml` | `GITHUB_TOKEN` for preview deploy + PR comments | `contents: write`, `pull-requests: write` |
| `zenodo-sync.yml` | `GITHUB_TOKEN` for Zenodo commit | `contents: write` |
| `test-publish.yml` | `GITHUB_TOKEN` for preview deploy, discussions, commit | `contents: write`, `discussions: write` |

Retired PATs: `GH_PAGES_TOKEN`, `GH_CONTENTS_WRITE_TOKEN`, plus the never-configured `GH_DISCUSSIONS_TOKEN` / `GH_PR_COMMENT_TOKEN`. The now-dead token-detection scaffolding and PAT-required validation steps are removed.

`GH_EDITORS_TOKEN` is retained — `read:org` cannot be done with `GITHUB_TOKEN`. External-service secrets (`ZENODO_API_TOKEN`, `ZENODO_COMMUNITY`, `BUTTONDOWN_API_KEY`) are unaffected; those have been re-pointed to org-owned accounts separately.

## Notes

- This also **enables** discussion auto-creation and PR-preview comments, which were silently skipped before because `GH_DISCUSSIONS_TOKEN` / `GH_PR_COMMENT_TOKEN` were never set as secrets.
- Neither `main` nor `gh-pages` is branch-protected, so `GITHUB_TOKEN` pushes are not blocked.
- Default repo token permission is `read`; the per-job `permissions:` blocks elevate to write where needed (GitHub's recommended pattern).

## After merge
Once a deploy run is verified green, delete the now-unused repo secrets:
- `GH_PAGES_TOKEN`
- `GH_CONTENTS_WRITE_TOKEN`