### PR TITLE
Test Zenodo community token workflow

### DIFF
--- a/content/blogs/2026-008/index.md
+++ b/content/blogs/2026-008/index.md
@@ -1,0 +1,45 @@
+---
+post_id: "2026-008"
+title: "Zenodo Community Token Validation Post"
+authors: ["Genomics X AI Editors"]
+
+authors_display:
+  - name: "Genomics X AI Editors"
+    affiliation: "Genomics x AI"
+    orcid: ""
+
+editor: "Genomics X AI Editors"
+
+tags: ["workflow", "doi", "testing"]
+categories: ["Announcement"]
+
+scope: ["insights"]
+audience: ["general"]
+labs: ["Genomics x AI"]
+
+status: "accepted"
+revision: 1
+
+date_submitted: 2026-05-22
+date_accepted: 2026-05-22
+date: 2026-05-22
+
+doi: ""
+zenodo_url: ""
+revision_history:
+  - version: 1
+    date: 2026-05-22
+    notes: "Initial Zenodo community token validation post"
+    doi: ""
+    zenodo_url: ""
+---
+
+{{< summary >}}
+This short post validates the Genomics x AI Zenodo account and community deposit workflow.
+{{< /summary >}}
+
+This is an operational workflow validation article for the Genomics x AI site.
+
+It confirms that a newly accepted blog post can move through the production publishing path with the current Zenodo API token and receive DOI metadata.
+
+After validation is complete, the site maintainers may withdraw this article from the public website while preserving the permanent Zenodo record created by the test.


### PR DESCRIPTION
## Summary
- Add a harmless accepted fake post to validate the current Zenodo production token and community deposit settings
- Uses post ID 2026-008 to avoid colliding with the pending 2026-007 blog PR

## Expected validation after merge
- Deploy workflow should mint a new DOI using ZENODO_API_TOKEN
- data/zenodo.json should get an entry for 2026-008
- The Zenodo record should be submitted/listed under the genomicsxai community if ZENODO_COMMUNITY is configured

## Verification
- hugo --minify