### PR TITLE
Recover Zenodo community token test metadata

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -108,7 +108,7 @@ jobs:
       - name: Commit Zenodo metadata
         if: steps.changed_blogs.outputs.count != '0'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.GH_CONTENTS_WRITE_TOKEN || github.token }}
         run: |
           if [ -z "$(git status --porcelain -- data/zenodo.json)" ]; then
             echo "No Zenodo metadata changes to commit."

--- a/content/blogs/2026-008/index.md
+++ b/content/blogs/2026-008/index.md
@@ -17,7 +17,8 @@ scope: ["insights"]
 audience: ["general"]
 labs: ["Genomics x AI"]
 
-status: "accepted"
+draft: true
+status: "withdrawn"
 revision: 1
 
 date_submitted: 2026-05-22

--- a/data/zenodo.json
+++ b/data/zenodo.json
@@ -130,5 +130,24 @@
         "notes": "Third workflow validation revision"
       }
     }
+  },
+  "2026-008": {
+    "conceptrecid": "20347357",
+    "current_revision": 1,
+    "current_doi": "10.5281/zenodo.20347358",
+    "current_doi_url": "https://doi.org/10.5281/zenodo.20347358",
+    "current_zenodo_url": "https://zenodo.org/records/20347358",
+    "current_deposition_id": 20347358,
+    "revisions": {
+      "1": {
+        "doi": "10.5281/zenodo.20347358",
+        "doi_url": "https://doi.org/10.5281/zenodo.20347358",
+        "zenodo_url": "https://zenodo.org/records/20347358",
+        "deposition_id": 20347358,
+        "record_id": 20347358,
+        "date": "2026-05-22",
+        "notes": "Initial Zenodo community token validation post"
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Record the DOI metadata minted by the successful Zenodo community token test for fake post 2026-008
- Withdraw the fake validation post from the public site
- Restore the Zenodo metadata push step to use GH_CONTENTS_WRITE_TOKEN so data/zenodo.json commits can bypass the default GITHUB_TOKEN branch-rule limitation

## Verification
- Zenodo record created: https://zenodo.org/records/20347358
- DOI: https://doi.org/10.5281/zenodo.20347358
- Record communities API includes genomicsxai
- ruby -rjson parse data/zenodo.json
- hugo --minify