### PR TITLE
Fix #74: enlarge figure legend input + clarify submission paths

### DIFF
--- a/content/page/submission-guidelines/index.md
+++ b/content/page/submission-guidelines/index.md
@@ -6,38 +6,66 @@ url: "/submission-guidelines/"
 
 ## Submit Your Blog Post
 
-The Genomics × AI blog uses a peer-reviewed, Git-native workflow. Write your
-post from the template, sign in with GitHub, and the form below will fork the
-repository, commit your files, and open a pull request — all automatically.
+The Genomics × AI blog uses a light, non-gate keeping peer-review, Git-native 
+workflow. There are **two ways to submit a post** — both go through the same 
+editorial review and produce the same final published post. Pick whichever 
+fits how you like to work:
 
-You'll need a [GitHub account](https://github.com/signup).
+- **Option 1 — Open a pull request.** Fastest path if you're already
+  comfortable with Git and Markdown: write your post locally, push a branch,
+  open a PR.
+- **Option 2 — Use the online submission form.** No local Git required. Sign
+  in with GitHub and either upload a template `index.md` or write the post
+  from scratch in the form's text fields. The form forks the repo, commits
+  your files, and opens the PR for you.
 
-{{< submission-form >}}
+You'll need a [GitHub account](https://github.com/signup) for either path.
 
 ---
 
-## How submission works
+### Option 1 — Open a pull request (for Git / Markdown users)
 
-1. **Write your post** — Download the template (button above), fill in the YAML
-   frontmatter, write your Summary + Sections, and run an internal lab review.
-2. **Submit via the form** — Upload your `index.md` and any images. The form
-   validates frontmatter, forks the repo, creates a branch, commits, and opens
-   a PR for you.
-3. **Preview** — Within a few minutes a bot posts a comment with a live preview
-   URL. It updates on each new commit. The preview may 404 for 1–2 minutes
-   while GitHub Pages propagates.
-4. **Editor review** — Editors run a lightweight
-   [Minimal Viable Review (MVR)](https://genomicsxai.github.io/editorial-review/)
-   for clarity, correctness, and fit. They may request changes via PR comments.
-5. **Going live** — Once approved, editors merge the PR and GitHub Actions
-   deploys the post.
-6. **Updates** — After your post is merged you can revise it through the same
-   form. Sign in, choose **Update one of my previous posts**, pick the post
-   from the dropdown (only posts you originally submitted appear), and add a
-   one-line revision note. You can either pre-fill the form from the published
-   version and edit, or start blank for a full rewrite. Submitting opens a PR
-   that bumps `revision`, appends to `revision_history`, and re-enters
-   editorial review.
+If you already work in Git, this is the quickest route:
+
+- [Fork the repository](https://github.com/genomicsxai/genomicsxai.github.io/fork).
+- Copy the
+  [blog post template](https://github.com/genomicsxai/genomicsxai.github.io/blob/main/docs/blog-post-template.md)
+  and fill in the YAML frontmatter.
+- Add your post to `content/blogs/YYYY-NNN/index.md`; place images in the
+  **same folder** (e.g. `content/blogs/YYYY-NNN/figure1.png`).
+- Your PR must contain **only** files inside `content/blogs/YYYY-NNN/` — no
+  changes to `static/`, `config.toml`, `.github/`, etc. If the preview bot
+  posts "Preview Deployment Skipped", the comment lists the offending files.
+- Open a pull request against `main`.
+
+To revise an already-published post, just open a new PR with your changes —
+editors will treat it as a revision and update `revision` /
+`revision_history` on merge.
+
+---
+
+### Option 2 — Use the online submission form (no Git required)
+
+If you'd rather not work in Git locally, the form below does the Git work
+for you. Sign in with GitHub and you can either:
+
+- **Upload a template `index.md`** (plus any images) — the form parses your
+  frontmatter and you can edit any field before submitting, or
+- **Write the post from scratch** in the form's text windows — fill in
+  title, authors, tags, scope, audience, summary, and body in dedicated
+  fields, with drag-and-drop image uploads and a caption per image.
+
+When you submit, the form validates the frontmatter, forks the repo, creates
+a branch, commits your files, and opens the PR on your behalf.
+
+{{< submission-form >}}
+
+**To revise an already-published post via the form**, sign in and choose
+**Update one of my previous posts**, then pick the post from the dropdown
+(only posts you originally submitted appear) and add a one-line revision
+note. You can either pre-fill the form from the published version and edit,
+or start blank for a full rewrite. Submitting opens a PR that bumps
+`revision`, appends to `revision_history`, and re-enters editorial review.
 
 On first use, the form asks you to authorize the **Genomics × AI Submission**
 OAuth app. It requests the `public_repo` scope — enough to fork, branch,
@@ -45,17 +73,21 @@ commit, and PR on your behalf. It can't read private repositories or change
 your account settings. Revoke any time from your
 [Authorized OAuth Apps](https://github.com/settings/applications).
 
-### Prefer Git? Submit a PR manually
+---
 
-If you'd rather work directly in Git:
+## What happens after you submit
 
-- [Fork the repository](https://github.com/genomicsxai/genomicsxai.github.io/fork).
-- Add your post to `content/blogs/YYYY-NNN/index.md`; place images in the
-  **same folder** (e.g. `content/blogs/YYYY-NNN/figure1.png`).
-- Your PR must contain **only** files inside `content/blogs/YYYY-NNN/` — no
-  changes to `static/`, `config.toml`, `.github/`, etc. If the preview bot
-  posts "Preview Deployment Skipped", the comment lists the offending files.
-- Open a pull request against `main` with the submission template filled out.
+Both options lead to the same review pipeline:
+
+1. **Preview** — Within a few minutes a bot posts a comment on your PR with a
+   live preview URL. It updates on each new commit. The preview may 404 for
+   1–2 minutes while GitHub Pages propagates.
+2. **Editor review** — Editors run a lightweight
+   [Minimal Viable Review (MVR)](https://genomicsxai.github.io/editorial-review/)
+   for clarity, correctness, and fit. They may request changes via PR
+   comments.
+3. **Going live** — Once approved, editors merge the PR and GitHub Actions
+   deploys the post.
 
 ## Writing notes
 

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -1377,12 +1377,15 @@ figure[data-image] figcaption {
   display: block;
   width: 100%;
   box-sizing: border-box;
-  padding: 4px 6px;
+  padding: 6px 8px;
   margin: 0;
   border: none;
   border-top: 1px solid var(--card-separator-color, rgba(218,218,218,0.5));
   font-family: inherit;
   font-size: 0.95rem;
+  line-height: 1.4;
+  min-height: 4.5em;
+  resize: vertical;
   background: var(--body-background, #fff);
   color: var(--card-text-color-main, inherit);
 }

--- a/static/js/submission-form.js
+++ b/static/js/submission-form.js
@@ -581,9 +581,9 @@
         span.className = 'submit-form__image-name';
         span.textContent = f.name + ' (' + (f.size / 1024).toFixed(0) + ' KB)';
 
-        var captionInput = document.createElement('input');
-        captionInput.type = 'text';
+        var captionInput = document.createElement('textarea');
         captionInput.className = 'submit-form__image-caption';
+        captionInput.rows = 3;
         captionInput.placeholder = 'Caption (figure legend, optional)';
         captionInput.value = self.captions[self.sanitizeName(f.name)] || '';
         captionInput.dataset.filename = self.sanitizeName(f.name);
@@ -1072,9 +1072,9 @@
         span.className = 'submit-form__image-name';
         span.textContent = f.name;
 
-        var captionInput = document.createElement('input');
-        captionInput.type = 'text';
+        var captionInput = document.createElement('textarea');
         captionInput.className = 'submit-form__image-caption';
+        captionInput.rows = 3;
         captionInput.placeholder = 'Caption (figure legend, optional)';
 
         var insertBtn = document.createElement('button');


### PR DESCRIPTION
Closes #74.

Two changes in this PR:

1. **#74 fix** — per-thumbnail caption input on the submission form is now a 3-row resizable textarea (was a single-line input), with matching CSS (padding, line-height, min-height, vertical resize). Touches `static/js/submission-form.js` and `static/css/custom.css`.

2. **Submission guidelines copy** — restructured `content/page/submission-guidelines/index.md` into two clearly parallel options: (1) open a PR (for Git/Markdown users), (2) use the online submission form (no Git required). Shared post-submission steps (preview, editor review, going live) lifted into their own section.

Verified locally with `hugo server`. PR-preview deploy will be skipped since changes are outside `content/blogs/`.