### PR TITLE
Fix #69: render LaTeX math in submission editor

### DIFF
--- a/layouts/partials/head/custom.html
+++ b/layouts/partials/head/custom.html
@@ -30,8 +30,15 @@
      them.
 
      Hashes computed against npm-published bytes (TinyMCE 7.6.0,
-     Turndown 7.2.0, Marked 13.0.3). Update both `src` version and
-     `integrity` together. */}}
+     Turndown 7.2.0, Marked 13.0.3, KaTeX 0.16.11). Update both `src`
+     version and `integrity` together.
+
+     KaTeX is loaded for the submission editor only — it renders the inline
+     ($...$) and block ($$...$$) math chips inside the TinyMCE iframe so
+     authors see the same KaTeX output the published post will have
+     (params.article.math). The katex.min.css file pulls webfonts from
+     jsDelivr at runtime which carry no SRI (same caveat as TinyMCE's
+     dynamic theme/plugin loads). */}}
 <script src="https://cdn.jsdelivr.net/npm/tinymce@7.6.0/tinymce.min.js"
         integrity="sha384-tra1rGs8OanGKq1dD4jTW195QKiytSZz7fE5gSASuwkxuhlG+KjvAVlyHOB2Mlva"
         crossorigin="anonymous"
@@ -42,6 +49,14 @@
         defer></script>
 <script src="https://cdn.jsdelivr.net/npm/marked@13.0.3/marked.min.js"
         integrity="sha384-YTBHtsL8yVTHcLakYNyrOfK3K+QQcXiECuaALJ+3j7Mo681Rtzadt8NR6WrZH+eQ"
+        crossorigin="anonymous"
+        defer></script>
+<link rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css"
+      integrity="sha384-nB0miv6/jRmo5UMMR1wu3Gz6NLsoTkbqJghGIsx//Rlm+ZU03BU6SQNC66uf4l5+"
+      crossorigin="anonymous">
+<script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js"
+        integrity="sha384-7zkQWkzuo3B5mTepMUcHkMB5jZaolc2xDwL6VFqjFALcbeS9Ggm/Yr2r3Dy4lfFg"
         crossorigin="anonymous"
         defer></script>
 <script src="{{ "js/submission-form.js" | relURL }}" defer></script>

--- a/layouts/shortcodes/submission-form.html
+++ b/layouts/shortcodes/submission-form.html
@@ -189,12 +189,6 @@
         <label class="submit-form__label" for="sf-date">Date</label>
         <input type="date" id="sf-date" class="submit-form__input" readonly>
       </div>
-
-      <div class="submit-form__field">
-        <label class="submit-form__checkbox">
-          <input type="checkbox" id="sf-math" class="submit-form__editable"> Post uses LaTeX math equations
-        </label>
-      </div>
     </div>
 
     <!-- Summary editor. Visible by default after Continue. -->

--- a/static/js/submission-editor.js
+++ b/static/js/submission-editor.js
@@ -27,8 +27,8 @@
   // a misconfigured page (logs once and bails so the rest of the form still
   // functions on the raw textareas as a fallback).
   document.addEventListener('DOMContentLoaded', function () {
-    if (!window.tinymce || !window.TurndownService || !window.marked) {
-      console.warn('[submission-editor] tinymce/turndown/marked not loaded — falling back to plain textareas.');
+    if (!window.tinymce || !window.TurndownService || !window.marked || !window.katex) {
+      console.warn('[submission-editor] tinymce/turndown/marked/katex not loaded — falling back to plain textareas.');
       // Make sure the hidden textareas are visible so the user can still type.
       var bodyTa = document.getElementById('submit-form__body-input');
       var summaryTa = document.getElementById('submit-form__summary-input');
@@ -69,17 +69,106 @@
           : '\n\n[image: ' + filename + ']\n\n';
       },
     });
-    // Turndown by default mangles consecutive newlines; that's fine for
-    // markdown, but leave block math alone.
+    // Math chips round-trip via their data-tex attribute, which holds the
+    // original LaTeX source. The KaTeX-rendered HTML inside the chip is
+    // for display only and isn't serialized back.
     turndown.addRule('blockMath', {
       filter: function (node) {
-        return node.nodeName === 'DIV' && node.getAttribute('data-math') === 'block';
+        return (node.nodeName === 'DIV' || node.nodeName === 'FIGURE') &&
+          node.getAttribute('data-math') === 'block';
       },
       replacement: function (_content, node) {
-        return '\n\n$$' + (node.textContent || '').trim() + '$$\n\n';
+        var tex = node.getAttribute('data-tex') || node.textContent || '';
+        return '\n\n$$' + tex.trim() + '$$\n\n';
+      },
+    });
+    turndown.addRule('inlineMath', {
+      filter: function (node) {
+        return node.nodeName === 'SPAN' && node.getAttribute('data-math') === 'inline';
+      },
+      replacement: function (_content, node) {
+        var tex = node.getAttribute('data-tex') || node.textContent || '';
+        return '$' + tex.trim() + '$';
       },
     });
     return turndown;
+  }
+
+  // ── LaTeX math rendering ─────────────────────────────────────────────────
+  // KaTeX renders the chip HTML; the original source is preserved on
+  // data-tex so the Turndown rules above can round-trip back to $...$ /
+  // $$...$$ markdown unchanged.
+  function renderMathChip(tex, displayMode) {
+    var html;
+    try {
+      html = window.katex.renderToString(tex, {
+        displayMode: !!displayMode,
+        throwOnError: false,
+        strict: 'ignore',
+        // Emit semantic MathML and let the browser render it natively
+        // (Chrome 109+, Safari, Firefox). KaTeX's HTML output uses
+        // top:-Xem offsets that rely on strut elements to push the
+        // line-box; inside TinyMCE's iframe those struts don't end up
+        // tall enough and superscripts paint above the chip. MathML
+        // avoids that whole chain — slightly different glyphs from the
+        // published post, but always positioned correctly.
+        output: 'mathml',
+      });
+    } catch (e) {
+      // Defensive: throwOnError:false should keep KaTeX from throwing,
+      // but if anything else goes wrong show the raw source so the author
+      // can still see and fix their input.
+      html = '<span class="sf-math-error">' + escapeHtml(tex) + '</span>';
+    }
+    var tag = displayMode ? 'div' : 'span';
+    var cls = displayMode ? 'sf-math sf-math--block' : 'sf-math sf-math--inline';
+    var dm = displayMode ? 'block' : 'inline';
+    return (
+      '<' + tag + ' class="' + cls + '" data-math="' + dm + '" ' +
+      'data-tex="' + escapeAttr(tex) + '" contenteditable="false">' +
+      html +
+      '</' + tag + '>'
+    );
+  }
+
+  // Marked v13 extension: tokenise inline $...$ and block $$...$$ before
+  // they reach the default text renderer (which would otherwise emit them
+  // as literal characters — the root cause of #69).
+  //
+  // Inline rule requires non-whitespace adjacent to both delimiters so we
+  // don't trigger on prices ($5) or stray dollar signs. Block rule is
+  // greedy across newlines.
+  function registerMarkedMathExtension() {
+    if (!window.marked || !window.marked.use) return;
+    if (window.marked.__sfMathRegistered) return;
+    window.marked.__sfMathRegistered = true;
+    window.marked.use({
+      extensions: [
+        {
+          name: 'sfBlockMath',
+          level: 'block',
+          start: function (src) { var i = src.indexOf('$$'); return i < 0 ? undefined : i; },
+          tokenizer: function (src) {
+            var m = /^\$\$([\s\S]+?)\$\$\s*/.exec(src);
+            if (!m) return undefined;
+            return { type: 'sfBlockMath', raw: m[0], tex: m[1].trim() };
+          },
+          renderer: function (token) { return renderMathChip(token.tex, true); },
+        },
+        {
+          name: 'sfInlineMath',
+          level: 'inline',
+          start: function (src) { var i = src.indexOf('$'); return i < 0 ? undefined : i; },
+          tokenizer: function (src) {
+            // $...$ where both edges are non-whitespace; reject $$ (block).
+            var m = /^\$(?!\$)((?:[^\s$][^$\n]*?[^\s$])|(?:[^\s$\n]))\$/.exec(src);
+            if (!m) return undefined;
+            return { type: 'sfInlineMath', raw: m[0], tex: m[1] };
+          },
+          renderer: function (token) { return renderMathChip(token.tex, false); },
+        },
+      ],
+    });
   }
 
   function htmlToMarkdown(html) {
@@ -191,6 +280,9 @@
       if (window.marked && window.marked.setOptions) {
         window.marked.setOptions({ gfm: true, breaks: false });
       }
+      // Register the $...$ / $$...$$ extension so math tokens become
+      // KaTeX-rendered chips instead of literal text.
+      registerMarkedMathExtension();
       this._initEditor('#submit-form__summary-editor', { isSummary: true })
         .then(function (ed) { self.summary = ed; });
       this._initEditor('#submit-form__body-editor', { isSummary: false })
@@ -212,6 +304,24 @@
         branding: false,
         menubar: false,
         statusbar: false,
+        // Allow MathML elements through TinyMCE's content filter. Without
+        // these, KaTeX's <math>...<mi>E</mi>...<msup><mi>c</mi><mn>2</mn>
+        // </msup>...</math> gets reduced to the inner text content
+        // ("E=mc2E=mc^2" — the second half being the <annotation> source)
+        // because TinyMCE strips elements it doesn't know about.
+        // custom_elements registers the tag names; ~ marks them as inline
+        // (no auto-block-wrap). extended_valid_elements lets every
+        // attribute through so KaTeX's inline styles/classes survive.
+        custom_elements:
+          '~math,~semantics,~mrow,~mi,~mo,~mn,~ms,~mtext,~mspace,' +
+          '~mfrac,~msqrt,~mroot,~msup,~msub,~msubsup,~mover,~munder,' +
+          '~munderover,~mtable,~mtr,~mtd,~mphantom,~menclose,~mpadded,' +
+          '~annotation,~annotation-xml',
+        extended_valid_elements:
+          'math[*],semantics[*],mrow[*],mi[*],mo[*],mn[*],ms[*],mtext[*],' +
+          'mspace[*],mfrac[*],msqrt[*],mroot[*],msup[*],msub[*],msubsup[*],' +
+          'mover[*],munder[*],munderover[*],mtable[*],mtr[*],mtd[*],' +
+          'mphantom[*],menclose[*],mpadded[*],annotation[*],annotation-xml[*]',
         height: opts.isSummary ? 180 : 480,
         min_height: opts.isSummary ? 120 : 320,
         plugins: 'lists link autolink table codesample paste autoresize wordcount',
@@ -236,6 +346,9 @@
           { text: 'Markdown', value: 'markdown' },
           { text: 'Plain text', value: 'text' },
         ],
+        // Pull KaTeX's stylesheet into the iframe so the rendered math
+        // chips look identical to the published post.
+        content_css: ['https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css'],
         // Style the image-reference chip inside the editor iframe. The chip
         // is just an inline marker for "an image will go here" — the actual
         // figure only renders on the published page.
@@ -255,7 +368,24 @@
           'line-height:1.5;overflow-x:auto;}' +
           'pre code{background:transparent;border:0;padding:0;color:inherit;}' +
           'code{background:#f1f3f5;border:1px solid #e2e8f0;border-radius:3px;padding:1px 5px;' +
-          'font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:0.92em;color:#b13a5e;}',
+          'font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:0.92em;color:#b13a5e;}' +
+          // Math chip styling — atomic, non-editable, visually distinct from
+          // surrounding prose so authors can see where math lives. Click-to-
+          // delete works as normal; the chip round-trips via its data-tex
+          // attribute (see turndown rules above). MathML inside the chip
+          // sizes itself correctly, so the chip just needs a styled box.
+          '.sf-math{background:#fffbeb;border:1px solid #fde68a;border-radius:4px;' +
+          'cursor:default;-webkit-user-select:none;user-select:none;}' +
+          '.sf-math--inline{display:inline-block;padding:2px 6px;margin:0 2px;' +
+          'vertical-align:middle;}' +
+          '.sf-math--block{display:block;text-align:center;padding:6px 12px;' +
+          'margin:14px auto;}' +
+          '.sf-math math{font-size:1.1em;}' +
+          // Annotations carry the LaTeX source for round-tripping; browsers
+          // that fully render MathML hide them automatically inside
+          // <semantics>, but force it for any that don\'t.
+          '.sf-math annotation,.sf-math annotation-xml{display:none;}' +
+          '.sf-math-error{color:#b91c1c;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:0.9em;}',
         // Tighten paste cleanup. TinyMCE handles MS Word / Google Docs by
         // default; these toggles strip extra inline styles so the markdown
         // round-trip is clean.
@@ -317,6 +447,13 @@
           editor.on('input change keyup undo redo blur SetContent', function () {
             self._syncToTextarea(editor, opts.isSummary);
           });
+          // Re-parse the markdown on blur so any $...$ / $$...$$ the user
+          // just typed becomes a KaTeX-rendered chip. The first handler
+          // above has already synced the latest markdown to the textarea
+          // by the time this fires, so we can read straight from it.
+          editor.on('blur', function () {
+            self._rerenderMath(editor, opts.isSummary);
+          });
         },
       }).then(function (editors) {
         // tinymce.init resolves with an array of editor instances.
@@ -356,6 +493,23 @@
       if (refs.FormController && typeof refs.FormController.revalidate === 'function') {
         try { refs.FormController.revalidate(); } catch (_) { /* ignore */ }
       }
+    },
+
+    // Re-parse the textarea's markdown back to HTML so any newly-typed
+    // $...$ / $$...$$ that's still sitting as literal text becomes a
+    // KaTeX-rendered chip. Called on editor blur. Skipped when the
+    // markdown has no $ — almost all blurs in practice.
+    _rerenderMath: function (editor, isSummary) {
+      if (!editor) return;
+      var ta = document.getElementById(
+        isSummary ? 'submit-form__summary-input' : 'submit-form__body-input'
+      );
+      if (!ta) return;
+      var md = ta.value || '';
+      if (md.indexOf('$') < 0) return;
+      var newHtml = markdownToHtml(md);
+      if (newHtml === editor.getContent()) return;
+      editor.setContent(newHtml);
     },
 
     // ── Public API used by submission-form.js ──────────────────────────────

--- a/static/js/submission-form.js
+++ b/static/js/submission-form.js
@@ -723,7 +723,6 @@
       lines.push('post_id: "' + fm.post_id + '"');
       lines.push('title: "' + (fm.title || '').replace(/"/g, '\\"') + '"');
       if (fm.image) lines.push('image: "' + fm.image + '"');
-      if (fm.math) lines.push('math: true');
       lines.push('');
 
       // authors
@@ -1340,10 +1339,6 @@
       $$('.submit-form__discipline').forEach(function (cb) {
         cb.checked = existingTags.indexOf(cb.dataset.slug) !== -1;
       });
-
-      // Math checkbox
-      var mathCb = $('#sf-math');
-      if (mathCb) mathCb.checked = !!fm.math;
     },
 
     bindAuthorRemoveButtons: function () {
@@ -1425,7 +1420,6 @@
       fm.date = ($('#sf-date') || {}).value || today();
       fm.date_submitted = fm.date_submitted || today();
       // DOI is assigned by Zenodo on publication, not set by the author.
-      fm.math = ($('#sf-math') || {}).checked || false;
 
       // Auto-set fields
       fm.editor = fm.editor || 'TBD';


### PR DESCRIPTION
Closes #69.

The TinyMCE-based submission editor was showing `$x^2$` and `$$E=mc^2$$` as literal text because Marked had no math extension and KaTeX was not loaded inside the iframe. This PR fixes that end-to-end.

## Changes

- **Load KaTeX 0.16.11** in `layouts/partials/head/custom.html`, SRI-pinned with `sha384-…` hashes computed against the npm-published bytes — same security pattern as the existing TinyMCE/Turndown/Marked loads.
- **Marked v13 extensions** for inline (`$...$`) and block (`$$...$$`) math. Inline rule requires non-whitespace at both delimiters so `$5 cost` is not treated as math; block rule fires only at block level.
- **Emit MathML, not KaTeX HTML.** `output: mathml` on `katex.renderToString`. KaTeX HTML positions superscripts via `top: -Xem` offsets that rely on strut elements to extend the surrounding line-box; inside the TinyMCE iframe those struts do not end up tall enough and superscripts paint above the chip (e.g. the `^2` in `E=mc^2` rendered on the line above). MathML is rendered natively by the browser (Chrome 109+, Safari, Firefox) and avoids the whole positioning chain. The trade-off is a small visual difference from the published post, which still uses KaTeX HTML — acceptable for an editor preview.
- **Allowlist MathML in TinyMCE.** TinyMCE 7s content filter strips `<math>`, `<mi>`, `<msup>`, etc. by default, reducing rendered math to bare text content (`E=mc2E=mc^2` — the first half from the stripped `mrow`, the second from the stripped `<annotation>`). Added `custom_elements` and `extended_valid_elements` registering the full set of MathML elements KaTeX emits, so they survive the filter.
- **Turndown round-trip rules** for both inline and block chips. Each chip carries a `data-tex` attribute with the original LaTeX source; the Turndown rules read from it so the serialized markdown is exactly `$...$` / `$$...$$` regardless of what the chip looks like internally.
- **Re-parse markdown on editor blur** so math typed directly in the editor (not just math loaded from an uploaded `index.md`) becomes a rendered chip without requiring a reload.
- **Chip styling** in TinyMCEs `content_style`: a soft yellow box matching the existing image-chip pattern, with an inline variant (vertical-align: middle) and a block variant (display: block, text-align: center).

## Side cleanup: removed the redundant "Post uses LaTeX math equations" checkbox

`params.article.math = true` in `config.toml` already enables KaTeX on every blog post. The per-post `math: true` frontmatter flag was therefore a no-op, and the checkbox in the form was misleading — authors who unticked it would (incorrectly) expect math not to render. Removed the checkbox UI from `layouts/shortcodes/submission-form.html` and its read/write/prefill plumbing from `static/js/submission-form.js`.

**Migration note:** when an existing post (e.g. 2026-002…2026-005) is re-saved through the form in update mode, the `math: true` line will be dropped from its frontmatter. This is harmless because the site-wide setting still loads KaTeX.

## Known limitation (not a regression)

Math chips are atomic — to edit a math expression, the author deletes the chip and retypes. Same pattern as the existing image chips. A click-to-edit dialog would be a reasonable follow-up if authors find this awkward.

Verified locally with `hugo server` against three paths: typing math directly into the editor, uploading a template with math, and round-tripping (chip → markdown → chip). PR-preview deploy will be skipped since changes are outside `content/blogs/`.