### PR TITLE
Fix #65 + add featured-image picker on submission form

### DIFF
--- a/layouts/shortcodes/submission-form.html
+++ b/layouts/shortcodes/submission-form.html
@@ -224,7 +224,7 @@
       <!-- Image upload, co-located with the body -->
       <div id="submit-form__images-subsection" class="submit-form__body-images">
         <h4 class="submit-form__subsection-title">Images</h4>
-        <p class="submit-form__help">Upload images you want to embed. Max 10 MB per file, 50 MB total. Type an optional <strong>caption</strong> next to each thumbnail (shown as the figure legend on the published page), then click <strong>Insert</strong> to drop a placeholder into the text above.</p>
+        <p class="submit-form__help">Upload images you want to embed. Max 10 MB per file, 50 MB total. Type an optional <strong>caption</strong> next to each thumbnail (shown as the figure legend on the published page), then click <strong>Insert</strong> to drop a placeholder into the text above. Click <strong>☆ Featured</strong> on any image to use it as the post's thumbnail (sets <code>image:</code> in the frontmatter).</p>
 
         <!-- Existing images carried over from the published post (update mode only) -->
         <div id="submit-form__existing-images-wrap" class="submit-form__existing-images" hidden>
@@ -243,6 +243,9 @@
 
     <!-- Submit -->
     <div id="submit-form__actions" class="submit-form__section">
+      <div id="submit-form__missing-summary" class="submit-form__missing-summary" hidden>
+        Please complete: <span id="submit-form__missing-list"></span>
+      </div>
       <button type="button" id="submit-form__submit-btn" class="submit-form__btn submit-form__btn--primary submit-form__btn--large" disabled>
         Submit Blog Post
       </button>

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -1194,11 +1194,23 @@ figure[data-image] figcaption {
   font-family: inherit;
   border: none;
   border-radius: 8px;
-  cursor: pointer;
   text-decoration: none;
   transition: opacity 0.2s, background 0.15s;
 }
-.submit-form__btn:hover { opacity: 0.85; }
+/* Cursor is declared on the enabled / disabled rules explicitly (not the
+   base) so each state has its own selector with matching specificity.
+   Chrome in particular can leave a stale `not-allowed` cursor on a button
+   whose `disabled` attribute was just removed dynamically until the
+   pointer leaves and re-enters; defining both states explicitly forces
+   the cursor to recompute when the attribute toggles. Matches both
+   `:disabled` (set via the IDL property — what revalidate() does) and
+   `[disabled]` (set via setAttribute) so either path stays styled. */
+.submit-form__btn:not(:disabled):not([disabled]) {
+  cursor: pointer;
+}
+.submit-form__btn:not(:disabled):not([disabled]):hover {
+  opacity: 0.85;
+}
 .submit-form__btn--primary {
   background: var(--accent-color, #34495e);
   color: #fff;
@@ -1223,9 +1235,29 @@ figure[data-image] figcaption {
 }
 .submit-form__btn--small { padding: 5px 12px; font-size: 1.3rem; }
 .submit-form__btn--large { padding: 12px 28px; font-size: 1.5rem; }
-.submit-form__btn:disabled {
+.submit-form__btn:disabled,
+.submit-form__btn[disabled] {
   opacity: 0.5;
   cursor: not-allowed;
+}
+
+/* Missing-fields summary above the Submit button. Populated by
+   FormController.revalidate() so authors who've scrolled past the
+   per-field error messages can see at a glance what's still needed. */
+.submit-form__missing-summary {
+  margin-bottom: 0.75rem;
+  padding: 8px 12px;
+  background: #fff5f0;
+  border: 1px solid #f5d3c0;
+  border-radius: 6px;
+  color: #b03a1a;
+  font-size: 1.3rem;
+  line-height: 1.5;
+}
+[data-scheme="dark"] .submit-form__missing-summary {
+  background: rgba(176, 58, 26, 0.12);
+  border-color: rgba(245, 211, 192, 0.3);
+  color: #f0b89a;
 }
 
 /* Drop zone */
@@ -1367,6 +1399,16 @@ figure[data-image] figcaption {
   overflow: hidden;
   background: var(--body-background, #fff);
 }
+/* Highlight the thumbnail the author picked as the post's featured image
+   so it's obvious at a glance which one will land in `image:` frontmatter. */
+.submit-form__image-thumb--featured {
+  border-color: #f59e0b;
+  box-shadow: 0 0 0 2px rgba(245, 158, 11, 0.2);
+}
+[data-scheme="dark"] .submit-form__image-thumb--featured {
+  border-color: #fbbf24;
+  box-shadow: 0 0 0 2px rgba(251, 191, 36, 0.3);
+}
 .submit-form__image-thumb img {
   width: 100%;
   height: 100px;
@@ -1436,6 +1478,37 @@ figure[data-image] figcaption {
   cursor: pointer;
 }
 .submit-form__image-insert:hover { opacity: 0.85; }
+
+/* ★ Featured toggle — sits below Insert in the thumbnail stack. Inactive
+   state is a low-key text button; .is-active gets the amber accent that
+   matches .submit-form__image-thumb--featured. */
+.submit-form__image-featured {
+  display: block;
+  width: 100%;
+  margin: 0;
+  padding: 4px 0;
+  background: transparent;
+  color: var(--card-text-color-secondary, #888);
+  border: none;
+  border-top: 1px solid rgba(0,0,0,0.08);
+  font-family: inherit;
+  font-size: 1.05rem;
+  font-weight: 500;
+  cursor: pointer;
+}
+.submit-form__image-featured:hover {
+  background: rgba(245, 158, 11, 0.08);
+  color: #b45309;
+}
+.submit-form__image-featured.is-active {
+  background: rgba(245, 158, 11, 0.14);
+  color: #b45309;
+  font-weight: 700;
+}
+[data-scheme="dark"] .submit-form__image-featured.is-active {
+  background: rgba(251, 191, 36, 0.18);
+  color: #fbbf24;
+}
 
 /* Co-located images sub-section inside the body editor */
 .submit-form__body-images {

--- a/static/js/submission-form.js
+++ b/static/js/submission-form.js
@@ -37,6 +37,19 @@
     try { return el ? JSON.parse(el.textContent) : []; } catch (e) { return []; }
   })();
 
+  // Human-readable labels for the keys Validate.run returns — used by
+  // revalidate() to populate the missing-fields summary above the Submit
+  // button. Keep aligned with the keys assigned in Validate.run.
+  var FIELD_LABELS = {
+    title: 'Title',
+    authors: 'Authors',
+    tags: 'Tags',
+    scope: 'Scope',
+    audience: 'Audience',
+    labs: 'Lab',
+    discipline: 'Discipline',
+  };
+
   // ── Utility ──
   function $(sel, ctx) { return (ctx || document).querySelector(sel); }
   function $$(sel, ctx) { return Array.from((ctx || document).querySelectorAll(sel)); }
@@ -501,6 +514,11 @@
     // filename (sanitized) -> caption string. Populated as the user types in the
     // per-thumb caption input; reset on removeFile/clear.
     captions: {},
+    // Sanitized filename of the image the author has marked as the post's
+    // thumbnail/featured image (serialized as `image:` in YAML frontmatter).
+    // May reference a new upload OR an existing image (update mode) — both
+    // render paths share this single piece of state. Empty string = none.
+    featuredFilename: '',
 
     addFiles: function (fileList) {
       var errors = [];
@@ -538,13 +556,24 @@
 
     removeFile: function (index) {
       var f = this.files[index];
-      if (f) delete this.captions[this.sanitizeName(f.name)];
+      if (f) {
+        var name = this.sanitizeName(f.name);
+        delete this.captions[name];
+        if (this.featuredFilename === name) this.featuredFilename = '';
+      }
       this.files.splice(index, 1);
     },
 
     clear: function () {
       this.files = [];
       this.captions = {};
+      this.featuredFilename = '';
+    },
+
+    // Toggle: clicking the same image clears the selection; clicking a
+    // different one switches. Caller is responsible for re-rendering.
+    setFeatured: function (filename) {
+      this.featuredFilename = (this.featuredFilename === filename) ? '' : filename;
     },
 
     sanitizeName: function (name) {
@@ -569,8 +598,11 @@
       container.innerHTML = '';
       var self = this;
       this.files.forEach(function (f, i) {
+        var sanitized = self.sanitizeName(f.name);
+        var isFeatured = self.featuredFilename === sanitized;
         var thumb = document.createElement('div');
-        thumb.className = 'submit-form__image-thumb';
+        thumb.className = 'submit-form__image-thumb' +
+          (isFeatured ? ' submit-form__image-thumb--featured' : '');
         var url = URL.createObjectURL(f);
 
         var img = document.createElement('img');
@@ -585,15 +617,23 @@
         captionInput.className = 'submit-form__image-caption';
         captionInput.rows = 3;
         captionInput.placeholder = 'Caption (figure legend, optional)';
-        captionInput.value = self.captions[self.sanitizeName(f.name)] || '';
-        captionInput.dataset.filename = self.sanitizeName(f.name);
+        captionInput.value = self.captions[sanitized] || '';
+        captionInput.dataset.filename = sanitized;
 
         var insertBtn = document.createElement('button');
         insertBtn.type = 'button';
         insertBtn.className = 'submit-form__image-insert';
-        insertBtn.dataset.filename = self.sanitizeName(f.name);
+        insertBtn.dataset.filename = sanitized;
         insertBtn.title = 'Insert at cursor in body';
         insertBtn.textContent = 'Insert';
+
+        var featuredBtn = document.createElement('button');
+        featuredBtn.type = 'button';
+        featuredBtn.className = 'submit-form__image-featured' +
+          (isFeatured ? ' is-active' : '');
+        featuredBtn.dataset.filename = sanitized;
+        featuredBtn.title = 'Set as post thumbnail (image: in frontmatter)';
+        featuredBtn.textContent = isFeatured ? '★ Featured' : '☆ Featured';
 
         var btn = document.createElement('button');
         btn.type = 'button';
@@ -606,6 +646,7 @@
         thumb.appendChild(span);
         thumb.appendChild(captionInput);
         thumb.appendChild(insertBtn);
+        thumb.appendChild(featuredBtn);
         thumb.appendChild(btn);
         container.appendChild(thumb);
       });
@@ -618,6 +659,16 @@
         btn.addEventListener('click', function () {
           self.removeFile(parseInt(btn.dataset.index, 10));
           self.renderPreviews();
+          if (UpdateMode.active) FormController.renderExistingImages();
+          FormController.revalidate();
+        });
+      });
+      $$('.submit-form__image-featured').forEach(function (btn) {
+        btn.addEventListener('click', function () {
+          self.setFeatured(btn.dataset.filename);
+          self.renderPreviews();
+          if (UpdateMode.active) FormController.renderExistingImages();
+          FormController.revalidate();
         });
       });
       $$('.submit-form__image-insert').forEach(function (btn) {
@@ -1009,6 +1060,13 @@
           };
           this.populateFields(UpdateMode.existingFrontmatter || {});
           this.setBody(UpdateMode.existingBody || '');
+          // Carry over the published post's `image:` so the existing-image
+          // thumb shows ★ Featured on load. User can re-pick from new
+          // uploads or clear via the toggle.
+          var existingImage = (UpdateMode.existingFrontmatter || {}).image;
+          ImageHandler.featuredFilename = existingImage
+            ? String(existingImage).toLowerCase()
+            : '';
           this.renderExistingImages();
           show($('#submit-form__fields'));
           show($('#submit-form__body-section'));
@@ -1059,8 +1117,11 @@
       imgFiles.forEach(function (f) {
         var thumb = document.createElement('div');
         var removed = !!UpdateMode.removedExistingImages[f.name];
+        var fname = f.name.toLowerCase();
+        var isFeatured = ImageHandler.featuredFilename === fname;
         thumb.className = 'submit-form__image-thumb submit-form__image-thumb--existing' +
-          (removed ? ' submit-form__image-thumb--removed' : '');
+          (removed ? ' submit-form__image-thumb--removed' : '') +
+          (isFeatured ? ' submit-form__image-thumb--featured' : '');
 
         var img = document.createElement('img');
         img.src = 'https://raw.githubusercontent.com/' + CONFIG.OWNER + '/' + CONFIG.REPO +
@@ -1099,6 +1160,19 @@
           FormController.revalidate();
         });
 
+        var featuredBtn = document.createElement('button');
+        featuredBtn.type = 'button';
+        featuredBtn.className = 'submit-form__image-featured' +
+          (isFeatured ? ' is-active' : '');
+        featuredBtn.title = 'Set as post thumbnail (image: in frontmatter)';
+        featuredBtn.textContent = isFeatured ? '★ Featured' : '☆ Featured';
+        featuredBtn.addEventListener('click', function () {
+          ImageHandler.setFeatured(fname);
+          FormController.renderExistingImages();
+          ImageHandler.renderPreviews();
+          FormController.revalidate();
+        });
+
         var keepBtn = document.createElement('button');
         keepBtn.type = 'button';
         keepBtn.className = 'submit-form__image-keep';
@@ -1108,14 +1182,23 @@
             delete UpdateMode.removedExistingImages[f.name];
           } else {
             UpdateMode.removedExistingImages[f.name] = true;
+            // If the user is removing the existing image they had featured,
+            // also drop the featured selection so submit doesn't fail the
+            // "image must exist" sanity check.
+            if (ImageHandler.featuredFilename === fname) {
+              ImageHandler.featuredFilename = '';
+              ImageHandler.renderPreviews();
+            }
           }
           FormController.renderExistingImages();
+          FormController.revalidate();
         });
 
         thumb.appendChild(img);
         thumb.appendChild(span);
         thumb.appendChild(captionInput);
         thumb.appendChild(insertBtn);
+        thumb.appendChild(featuredBtn);
         thumb.appendChild(keepBtn);
         container.appendChild(thumb);
       });
@@ -1233,6 +1316,13 @@
         self.parsed = result;
         self.populateFields(result.frontmatter);
         self.setBody(result.body || '');
+        // Mirror an `image: foo.png` from the uploaded frontmatter into the
+        // ★ Featured selection so the right thumbnail lights up as soon as
+        // the user drops foo.png into the Images section.
+        if (result.frontmatter && result.frontmatter.image) {
+          ImageHandler.featuredFilename = String(result.frontmatter.image).toLowerCase();
+          ImageHandler.renderPreviews();
+        }
         self.revalidate();
         show($('#submit-form__fields'));
         show($('#submit-form__body-section'));
@@ -1417,6 +1507,17 @@
       var labsVal = ($('#sf-labs') || {}).value || '';
       fm.labs = labsVal.split(',').map(function (l) { return l.trim(); }).filter(Boolean);
 
+      // Featured/thumbnail image — driven by the ★ Featured toggle on the
+      // image previews. The post-submit sanity check (around line 1543)
+      // verifies the named image still exists in the uploads before the PR
+      // is opened, so a stale value (e.g. user deselected after upload)
+      // gets cleaned up there too.
+      if (ImageHandler.featuredFilename) {
+        fm.image = ImageHandler.featuredFilename;
+      } else {
+        delete fm.image;
+      }
+
       fm.date = ($('#sf-date') || {}).value || today();
       fm.date_submitted = fm.date_submitted || today();
       // DOI is assigned by Zenodo on publication, not set by the author.
@@ -1464,6 +1565,23 @@
         var errEl = $('#sf-error-' + field);
         if (errEl) { errEl.textContent = errors[field]; show(errEl); }
       });
+
+      // Mirror the missing/invalid fields into a summary line right above
+      // the Submit button so authors who've scrolled past the per-field
+      // errors can still tell at a glance what's blocking submission.
+      var missingSummary = $('#submit-form__missing-summary');
+      var missingList = $('#submit-form__missing-list');
+      if (missingSummary && missingList) {
+        var keys = Object.keys(errors);
+        if (keys.length === 0) {
+          hide(missingSummary);
+        } else {
+          missingList.textContent = keys.map(function (k) {
+            return FIELD_LABELS[k] || k;
+          }).join(', ');
+          show(missingSummary);
+        }
+      }
 
       var submitBtn = $('#submit-form__submit-btn');
       if (submitBtn) submitBtn.disabled = Validate.hasErrors(errors);


### PR DESCRIPTION
Closes #65. Also adds the small follow-up of a featured-image picker on the submission form — same area of code, paid the editor-side overhead once.

## Part 1 — Submit button cursor + missing-fields summary (the #65 fix)

The reported symptom was the Submit button showing `cursor: not-allowed` even when the form was valid. The only `cursor: not-allowed` rule in the project is `.submit-form__btn:disabled` in `static/css/custom.css`. When `FormController.revalidate()` clears the `disabled` attribute, Chrome can leave a stale `:disabled` cursor on a hovered button until the pointer leaves and re-enters — a known browser quirk.

CSS fix:

- Move `cursor: pointer` off the base `.submit-form__btn` onto `:not(:disabled):not([disabled])` so enabled and disabled cursors each have their own selector with matching specificity. Browser is forced to do a fresh cursor resolution on every attribute toggle instead of inheriting a cached value.
- Match disabled on both `:disabled` (IDL property — what `revalidate()` sets) and `[disabled]` (`setAttribute`), so either code path stays styled.
- Gate `:hover` opacity on the same `:not()` chain so a disabled-but-hovered button doesnt get the enabled `0.85` fighting the disabled `0.5`.

While testing it became clear that when the button is *genuinely* disabled (validation actually failing), authors had no easy way to see *which* required field was the problem — per-field error text is rendered next to each field, which is invisible once theyve scrolled to the bottom to click Submit. The Discipline checkbox group was the most common silent failure.

So also added a one-line summary directly above the Submit button:

> **Please complete: Discipline, Lab**

`revalidate()` now also maps each error key through a `FIELD_LABELS` table and writes the names into the summary, hiding it when there are no errors.

## Part 2 — Featured-image picker

`fm.image` was already serialized to YAML at line 738 and sanity-checked against uploads at line 1543, but there was no UI to actually pick one — `image:` frontmatter could only be set by uploading an `index.md` that already had it. Manual form-fillers had no way to give their post a thumbnail.

Added a `★ Featured` toggle button to each image thumbnail (both new uploads and the existing-images path in update mode). Click sets `ImageHandler.featuredFilename`; clicking the same one clears; clicking a different one switches. The featured thumb gets an amber border + glow that matches the active button.

Wiring:

- `readFieldsToFrontmatter` writes the selection into `fm.image`.
- `loadMarkdownFile` mirrors any `image:` from the uploaded frontmatter into `ImageHandler.featuredFilename`, so the matching upload lights up the moment it lands in the gallery.
- `UpdateMode` prefill carries the published posts `image:` into the picker so the existing-image thumb shows ★ on load.
- Removing the featured image (via × on new uploads or `Remove` in update mode) auto-clears the selection so the post-submit sanity check doesnt silently drop a stale `fm.image`.

## Verified

`hugo server` → `/submission-guidelines/`:

- Cursor: fill / unfill required fields, missing-fields summary updates live, cursor flips between `pointer` and `not-allowed` cleanly.
- Featured: drop images, click ☆ to mark one, click another to switch, click same to clear. Upload an `index.md` with `image: foo.png`, then drop foo.png in — it lights up as featured.
- Update mode: pick a published post → existing image referenced by the posts `image:` shows ★ Featured on load.

PR-preview deploy will be skipped since changes are outside `content/blogs/`.