### PR TITLE
Fix #64: convert editor tables to GFM pipe-table markdown

### DIFF
--- a/static/js/submission-editor.js
+++ b/static/js/submission-editor.js
@@ -91,7 +91,69 @@
         return '$' + tex.trim() + '$';
       },
     });
+    // GFM pipe-table converter. TinyMCE\'s table plugin emits standard
+    // <table><tbody>...</tbody></table>; Turndown\'s default leaves that
+    // as raw HTML in the markdown output, which Hugo\'s goldmark/GFM
+    // renders inconsistently (often broken if the block ends up adjacent
+    // to a paragraph). Emit a proper pipe-table block so the published
+    // post gets the same styled table a hand-written |---|---| would.
+    turndown.addRule('gfmTable', {
+      filter: 'table',
+      replacement: function (_content, node) { return convertTableToGfm(node); },
+    });
     return turndown;
+  }
+
+  // Walk an HTML <table> and emit a GFM pipe-table block. First row
+  // becomes the header; the rest become body rows; the separator runs
+  // the full cell-count width. Cell content is run back through the
+  // shared Turndown instance so inline formatting (bold/italic/code/
+  // links) survives — collapsed to a single line and pipe-escaped so
+  // the cell stays inside its `| ... |` boundary.
+  function convertTableToGfm(table) {
+    var rows = Array.prototype.slice.call(table.querySelectorAll('tr'));
+    if (rows.length === 0) return '';
+
+    var cellCount = 0;
+    rows.forEach(function (row) {
+      var cells = row.querySelectorAll('td, th');
+      if (cells.length > cellCount) cellCount = cells.length;
+    });
+    if (cellCount === 0) return '';
+
+    function cellMd(cell) {
+      // Nested <table> inside a cell can\'t round-trip to a pipe table
+      // (GFM has no nested-table syntax); flatten to text so we don\'t
+      // recurse into an invalid construct.
+      if (cell.querySelector('table')) {
+        return (cell.textContent || '')
+          .replace(/\|/g, '\\|').replace(/\s+/g, ' ').trim();
+      }
+      var md = getTurndown().turndown(cell.innerHTML || '');
+      return md
+        .replace(/\|/g, '\\|')
+        .replace(/\r?\n+/g, ' ')
+        .replace(/\s+/g, ' ')
+        .trim();
+    }
+
+    function rowMd(row) {
+      var cells = Array.prototype.slice.call(row.querySelectorAll('td, th'));
+      var parts = [];
+      for (var i = 0; i < cellCount; i++) {
+        parts.push(cells[i] ? cellMd(cells[i]) : '');
+      }
+      return '| ' + parts.join(' | ') + ' |';
+    }
+
+    var lines = [rowMd(rows[0])];
+    var seps = [];
+    for (var k = 0; k < cellCount; k++) seps.push('---');
+    lines.push('| ' + seps.join(' | ') + ' |');
+    for (var j = 1; j < rows.length; j++) {
+      lines.push(rowMd(rows[j]));
+    }
+    return '\n\n' + lines.join('\n') + '\n\n';
   }
 
   // ── LaTeX math rendering ─────────────────────────────────────────────────


### PR DESCRIPTION
Closes #64.

TinyMCE's `table` plugin emits standard `<table><tbody>...</tbody></table>` HTML. Turndown's default behaviour keeps that as raw HTML in the markdown output, which Hugo's goldmark/GFM parser renders inconsistently — usually broken when the block ends up adjacent to a paragraph or without surrounding blank lines.

## Fix

Add a custom Turndown rule in `static/js/submission-editor.js` that walks the `<table>` and emits a GFM pipe-table block. First `<tr>` becomes the header, separator row spans the full cell count, remaining rows become the body. Each cell's `innerHTML` is run back through the shared Turndown instance so inline formatting (`**bold**`, `*italic*`, `` `code` ``, `[link](url)`) survives the conversion.

Handled:
- Pipes inside cell text are escaped (`\|`) so they don't close the cell.
- Multi-line cell content collapses to a single line (required by GFM pipe-table syntax).
- Ragged rows (different cell counts) pad to the widest row so the column structure stays valid.
- Nested `<table>` inside a cell falls back to `textContent` — GFM has no nested-table syntax to round-trip into.

## What was already working

The MD → HTML direction. `marked.setOptions({ gfm: true })` is already set in `SubmissionEditor.init()`, so an uploaded `index.md` containing a pipe table is parsed and emitted as a real `<table>` element that TinyMCE renders correctly. Update-mode pre-fill goes through the same `markdownToHtml()` path. The bug was only in HTML → MD (Turndown).

## Verified

`hugo server` → `/submission-guidelines/`:
- Insert a table via the toolbar, type formatted content into cells, inspect `#submit-form__body-input` → proper pipe-table syntax with formatting preserved.
- Upload an `index.md` containing a pipe table → renders as a real table in the editor; serializes back unchanged.

PR-preview deploy will be skipped since changes are outside `content/blogs/`.