### PR TITLE
Fix weekly newsletter digest: full git history + dated subject

### DIFF
--- a/.github/workflows/newsletter.yml
+++ b/.github/workflows/newsletter.yml
@@ -21,6 +21,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Need full history for the git-log-based new-post filter below
+          # (`git log --follow` on each blog index.md to find its first-add
+          # commit date). The default fetch-depth: 1 only fetches the tip,
+          # so the "oldest" commit visible to git log is whatever single
+          # commit was cloned — which makes any post touched by the tip
+          # commit look new. With fetch-depth: 0 the filter can find each
+          # post's actual initial commit.
+          fetch-depth: 0
 
       - name: Find new posts and build email
         id: build
@@ -144,16 +153,24 @@ jobs:
 
           python3 - <<'PYEOF'
           import json, os, urllib.request, urllib.error
+          from datetime import datetime, timezone
 
           posts = json.load(open("/tmp/new_posts.json"))
           status = os.environ["STATUS"]
           api_key = os.environ["BUTTONDOWN_API_KEY"]
 
+          # Date suffix on every subject so Buttondown's email_duplicate
+          # dedup check (HTTP 400) doesn't reject this week's digest when a
+          # previous week's subject was identical — most often the multi-post
+          # case "...: N new posts", which would otherwise collide whenever
+          # N happens to be the same N weeks in a row.
+          today_iso = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
           count = len(posts)
           if count == 1:
-              subject = f"New on Genomics × AI: {posts[0]['title']}"
+              subject = f"New on Genomics × AI: {posts[0]['title']} ({today_iso})"
           else:
-              subject = f"New on Genomics × AI: {count} new posts"
+              subject = f"New on Genomics × AI: {count} new posts ({today_iso})"
 
           # Build HTML email
           lines = [


### PR DESCRIPTION
The weekly newsletter job [failed on 2026-06-01](https://github.com/genomicsxai/genomicsxai.github.io/actions/runs/26764278294/job/78886161541) with:



Two compounding causes:

## 1. `actions/checkout@v4` was shallow-cloning, breaking the git-log filter

The job uses `git log --follow --pretty=format:%ci -- $path` on each blog `index.md` and takes the oldest returned commit as the post's first-add date. With the default `fetch-depth: 1`, only the tip commit is in the local repo — so `git log` can only return that one commit, and the "oldest" visible commit ends up being whatever happened most recently. Any post touched by the tip commit looked new. That's how the job found 7 "new" posts when only one was actually added in the last 7 days.

Fix: set `fetch-depth: 0` on the checkout step so the filter has full history to walk.

Verified locally that with full history the script correctly identifies `2026-002` (originally committed 2026-02-20) as not new.

## 2. Buttondown's `email_duplicate` rejected the digest as a duplicate of a prior week's

The multi-post subject template was `New on Genomics × AI: N new posts` — identical week over week whenever `N` repeated. Buttondown's dedup check matches subject + body similarity and returns HTTP 400 `email_duplicate`.

Fix: append the current UTC date as a `(YYYY-MM-DD)` suffix on both subject formats so each weekly digest has a unique subject.

## How to verify

Trigger a manual run from the Actions tab with `dry_run = true` (default). Expected behaviour after this PR:

- `find new posts` step reports a much smaller, accurate count (most weeks: 0 or 1)
- If the count is 0, the job exits 0 with "No new posts in the last 7 days — skipping newsletter."
- If non-zero, the resulting Buttondown draft has a `(YYYY-MM-DD)` suffix in the subject and no `email_duplicate` rejection.

Then let the next Monday cron run land naturally.
