### PR TITLE
Add 'Paper Reviews' category to blog

### DIFF
--- a/docs/BLOG_SPEC.md
+++ b/docs/BLOG_SPEC.md
@@ -130,12 +130,13 @@ Writer of the post. Author pages at `/authors/<slug>/` (affiliation, ORCID, webs
 
 Determines which homepage pill filter a post appears under.
 
-Supported values: **Announcement**, **Blog Post**, **Tutorial**, **Perspective**.
+Supported values: **Announcement**, **Blog Post**, **Tutorial**, **Perspective**, **Paper Reviews**.
 
 - `Announcement` — editorial and community announcements (appears under the **Announcements** pill)
 - `Blog Post` — standard research write-ups (appears under the **Blogs** pill)
 - `Tutorial` — step-by-step technical guides (appears under the **Tutorials** pill)
 - `Perspective` — opinion pieces, field commentary (appears under the **Perspectives** pill)
+- `Paper Reviews` — write-ups summarising or critiquing a published paper (appears under the **Paper Reviews** pill)
 
 The homepage pill bar reads the `categories` taxonomy only, not `scope`. A post with `scope: ["tutorials"]` but `categories: ["Blog Post"]` will appear under the Blogs pill, not Tutorials.
 

--- a/docs/blog-post-template.md
+++ b/docs/blog-post-template.md
@@ -29,11 +29,12 @@ editor: "Editor Name"
 # Add any number of tags. They're searchable on the blog homepage. See https://genomicsxai.github.io/tags/ for examples.
 tags: ["genomics", "causal-inference"]
 # Category determines which homepage pill filter the post appears under.
-# Supported values: "Announcement", "Blog Post", "Tutorial", "Perspective"
-#   - "Announcement" → appears under the Announcements pill (editorial/community announcements)
-#   - "Blog Post"    → appears under the Blogs pill (default for most posts)
-#   - "Tutorial"     → appears under the Tutorials pill (step-by-step technical guides)
-#   - "Perspective"  → appears under the Perspectives pill (opinion pieces, commentary)
+# Supported values: "Announcement", "Blog Post", "Tutorial", "Perspective", "Paper Reviews"
+#   - "Announcement"  → appears under the Announcements pill (editorial/community announcements)
+#   - "Blog Post"     → appears under the Blogs pill (default for most posts)
+#   - "Tutorial"      → appears under the Tutorials pill (step-by-step technical guides)
+#   - "Perspective"   → appears under the Perspectives pill (opinion pieces, commentary)
+#   - "Paper Reviews" → appears under the Paper Reviews pill (summaries/critiques of a published paper)
 # Note: the homepage pills filter by `categories` only, not by `scope`.
 categories: ["Blog Post"]
 

--- a/layouts/partials/widget/category-pills.html
+++ b/layouts/partials/widget/category-pills.html
@@ -31,12 +31,13 @@
     <a href="{{ site.Home.RelPermalink }}"
        class="category-pills__pill{{ if eq $currentCat "all" }} category-pills__pill--active{{ end }}"
        data-filter="all">All</a>
-    {{- range $cat := slice "Announcement" "Blog Post" "Tutorial" "Perspective" -}}
+    {{- range $cat := slice "Announcement" "Blog Post" "Tutorial" "Perspective" "Paper Reviews" -}}
       {{- $slug := . | urlize -}}
       {{- $label := "Perspectives" -}}
       {{- if eq . "Announcement" }}{{ $label = "Announcements" }}
       {{- else if eq . "Blog Post" }}{{ $label = "Blogs" }}
       {{- else if eq . "Tutorial" }}{{ $label = "Tutorials" }}
+      {{- else if eq . "Paper Reviews" }}{{ $label = "Paper Reviews" }}
       {{- end -}}
       {{- $isActive := eq $currentCat $slug -}}
       {{- $termPage := site.GetPage (printf "/categories/%s" $slug) -}}


### PR DESCRIPTION
Adds a new homepage category alongside the existing four (Announcement, Blog Post, Tutorial, Perspective):

- layouts/partials/widget/category-pills.html: extend the pill slice and add an explicit label branch so the pill renders as 'Paper Reviews' (using just 'Reviews' would collide with editorial reviews).
- docs/BLOG_SPEC.md and docs/blog-post-template.md: extend the supported-values list and add a per-value bullet describing the category as 'write-ups summarising or critiquing a published paper'.

The Hugo categories taxonomy auto-creates the term page from any post that adopts the new value, so the pill will activate as soon as the first Paper Reviews post lands. The validator only checks that categories: is present, not the values, so no allowlist to update.

# Blog Post Submission

- [ ] Post uses the [blog post template](https://github.com/genomicsxai/genomicsxai.github.io/blob/main/docs/blog-post-template.md) and required frontmatter is complete
- [ ] Content follows [submission guidelines](https://genomicsxai.github.io/submission-guidelines/)
- [ ] Lab review completed
- [ ] Links and assets validated

## Notes for Editors

(Any additional information for reviewers)
