### PR TITLE
Add category picker to submission form

### DIFF
--- a/layouts/shortcodes/submission-form.html
+++ b/layouts/shortcodes/submission-form.html
@@ -146,6 +146,58 @@
       </div>
 
       <div class="submit-form__field">
+        <label class="submit-form__label submit-form__label--required">Category</label>
+        <span class="submit-form__help">Which homepage pill your post appears under. Default is <strong>Blog Post</strong> — pick another only if it clearly fits.</span>
+        <div class="submit-form__radio-group">
+          <div class="submit-form__radio-item">
+            <label class="submit-form__radio">
+              <input type="radio" name="sf-category" value="Announcement" class="submit-form__editable">
+              <span class="submit-form__radio-label">
+                Announcement
+                <span class="submit-form__radio-note">Editorial and community announcements.</span>
+              </span>
+            </label>
+          </div>
+          <div class="submit-form__radio-item">
+            <label class="submit-form__radio">
+              <input type="radio" name="sf-category" value="Blog Post" class="submit-form__editable" checked>
+              <span class="submit-form__radio-label">
+                Blog Post <em>(default)</em>
+                <span class="submit-form__radio-note">Standard research write-ups.</span>
+              </span>
+            </label>
+          </div>
+          <div class="submit-form__radio-item">
+            <label class="submit-form__radio">
+              <input type="radio" name="sf-category" value="Tutorial" class="submit-form__editable">
+              <span class="submit-form__radio-label">
+                Tutorial
+                <span class="submit-form__radio-note">Step-by-step technical guides.</span>
+              </span>
+            </label>
+          </div>
+          <div class="submit-form__radio-item">
+            <label class="submit-form__radio">
+              <input type="radio" name="sf-category" value="Perspective" class="submit-form__editable">
+              <span class="submit-form__radio-label">
+                Perspective
+                <span class="submit-form__radio-note">Opinion pieces, field commentary.</span>
+              </span>
+            </label>
+          </div>
+          <div class="submit-form__radio-item">
+            <label class="submit-form__radio">
+              <input type="radio" name="sf-category" value="Paper Reviews" class="submit-form__editable">
+              <span class="submit-form__radio-label">
+                Paper Reviews
+                <span class="submit-form__radio-note">Summaries or critiques of a published paper.</span>
+              </span>
+            </label>
+          </div>
+        </div>
+      </div>
+
+      <div class="submit-form__field">
         <label class="submit-form__label submit-form__label--required">Scope</label>
         <div class="submit-form__checkbox-group">
           <label class="submit-form__checkbox"><input type="checkbox" id="sf-scope-protocols" class="submit-form__editable"> protocols</label>

--- a/static/js/submission-form.js
+++ b/static/js/submission-form.js
@@ -1429,6 +1429,26 @@
       $$('.submit-form__discipline').forEach(function (cb) {
         cb.checked = existingTags.indexOf(cb.dataset.slug) !== -1;
       });
+
+      // Category radio — uploaded/prefilled `categories: [...]` ticks the
+      // matching radio; if no match (legacy/unknown value) or no value at
+      // all, fall back to "Blog Post" so the form always has a valid choice.
+      var fmCategory = (Array.isArray(fm.categories) && fm.categories.length > 0)
+        ? String(fm.categories[0])
+        : 'Blog Post';
+      var matched = false;
+      $$('input[name="sf-category"]').forEach(function (r) {
+        if (r.value === fmCategory) {
+          r.checked = true;
+          matched = true;
+        } else {
+          r.checked = false;
+        }
+      });
+      if (!matched) {
+        var fallback = $('input[name="sf-category"][value="Blog Post"]');
+        if (fallback) fallback.checked = true;
+      }
     },
 
     bindAuthorRemoveButtons: function () {
@@ -1524,7 +1544,14 @@
 
       // Auto-set fields
       fm.editor = fm.editor || 'TBD';
-      fm.categories = fm.categories || ['Blog Post'];
+      // Category — read from the radio group. The HTML pre-checks the
+      // "Blog Post" radio so this always returns a value; the fm.categories
+      // fallback only matters if the radios somehow aren't in the DOM
+      // (e.g. JS run before shortcode rendered).
+      var categoryRadio = $('input[name="sf-category"]:checked');
+      fm.categories = categoryRadio
+        ? [categoryRadio.value]
+        : (fm.categories || ['Blog Post']);
       fm.status = 'submitted';
 
       if (UpdateMode.active) {


### PR DESCRIPTION
The weekly newsletter job [failed on 2026-06-01](https://github.com/genomicsxai/genomicsxai.github.io/actions/runs/26764278294/job/78886161541) with:



Two compounding causes:

## 1. `actions/checkout@v4` was shallow-cloning, breaking the git-log filter

The job uses `git log --follow --pretty=format:%ci -- $path` on each blog `index.md` and takes the oldest returned commit as the post's first-add date. With the default `fetch-depth: 1`, only the tip commit is in the local repo — so `git log` can only return that one commit, and the "oldest" visible commit ends up being whatever happened most recently. Any post touched by the tip commit looked new. That's how the job found 7 "new" posts when only one was actually added in the last 7 days.

Fix: set `fetch-depth: 0` on the checkout step so the filter has full history to walk.

Verified locally that with full history the script correctly identifies `2026-002` (originally committed 2026-02-20) as not new.

## 2. Buttondown's `email_duplicate` rejected the digest as a duplicate of a prior week's

The multi-post subject template was `New on Genomics × AI: N new posts` — identical week over week whenever `N` repeated. Buttondown's dedup check matches subject + body similarity and returns HTTP 400 `email_duplicate`.

Fix: append the current UTC date as a `(YYYY-MM-DD)` suffix on both subject formats so each weekly digest has a unique subject.

## How to verify

Trigger a manual run from the Actions tab with `dry_run = true` (default). Expected behaviour after this PR:

- `find new posts` step reports a much smaller, accurate count (most weeks: 0 or 1)
- If the count is 0, the job exits 0 with "No new posts in the last 7 days — skipping newsletter."
- If non-zero, the resulting Buttondown draft has a `(YYYY-MM-DD)` suffix in the subject and no `email_duplicate` rejection.

Then let the next Monday cron run land naturally.
