### PR TITLE
Align blog post 2026-007 Zenodo frontmatter

### DIFF
--- a/content/blogs/2026-007/index.md
+++ b/content/blogs/2026-007/index.md
@@ -32,6 +32,7 @@ date_accepted: 2026-06-25
 date: 2026-06-25
 
 doi: ""
+zenodo_url: ""
 revision_history:
   - version: 1
     date: 2026-05-21


### PR DESCRIPTION
Adds the blank zenodo_url frontmatter field for post 2026-007, matching the blog template and triggering the production deploy now that data/zenodo.json contains the minted DOI metadata.\n\nValidated locally:\n- .github/scripts/validate-blog.sh\n- hugo --minify\n- JSON parse for data/zenodo.json