### PR TITLE
Add Altmetric badges for DOI-backed posts

### DIFF
--- a/.github/scripts/validate-scholar-metadata.rb
+++ b/.github/scripts/validate-scholar-metadata.rb
@@ -31,6 +31,20 @@ def meta_values(html, name)
   end
 end
 
+def altmetric_dois(html)
+  html.scan(/<div\b[^>]*>/i).filter_map do |tag|
+    classes = tag[/\bclass\s*=\s*"([^"]*)"/i, 1] ||
+              tag[/\bclass\s*=\s*'([^']*)'/i, 1] ||
+              tag[/\bclass\s*=\s*([^\s>]+)/i, 1]
+    next unless classes.to_s.split.include?("altmetric-embed")
+
+    doi = tag[/\bdata-doi\s*=\s*"([^"]*)"/i, 1] ||
+          tag[/\bdata-doi\s*=\s*'([^']*)'/i, 1] ||
+          tag[/\bdata-doi\s*=\s*([^\s>]+)/i, 1]
+    CGI.unescapeHTML(doi.to_s)
+  end
+end
+
 def expected_authors(fm)
   authors = fm["authors_display"] || fm["authors"] || []
   authors.map { |author| author.is_a?(Hash) ? author["name"] : author }.compact
@@ -77,6 +91,7 @@ Dir.glob(File.join(ROOT, "content", "blogs", "*", "index.md")).sort.each do |pat
   html = File.read(html_path)
   expected_url = "#{BASE_URL}/blogs/#{post_id}/"
   expected_doi = zenodo.dig(post_id, "current_doi").to_s
+  expected_doi = fm["doi"].to_s if expected_doi.empty?
 
   title_values = meta_values(html, "citation_title")
   errors << "#{path}: missing citation_title" if title_values.empty?
@@ -102,8 +117,19 @@ Dir.glob(File.join(ROOT, "content", "blogs", "*", "index.md")).sort.each do |pat
 
   if expected_doi.empty?
     errors << "#{path}: accepted post is missing Zenodo DOI metadata" if REQUIRE_ACCEPTED_DOI
+    errors << "#{path}: Altmetric badge must not render without a DOI" unless altmetric_dois(html).empty?
+    if html.include?("https://embed.altmetric.com/assets/embed.js")
+      errors << "#{path}: Altmetric embed script must not load without a DOI"
+    end
   elsif !meta_values(html, "citation_doi").include?(expected_doi)
     errors << "#{path}: citation_doi must be #{expected_doi}"
+  else
+    unless altmetric_dois(html).include?(expected_doi)
+      errors << "#{path}: Altmetric badge data-doi must be #{expected_doi}"
+    end
+
+    embed_script_count = html.scan(%r{https://embed\.altmetric\.com/assets/embed\.js}).length
+    errors << "#{path}: expected one Altmetric embed script, found #{embed_script_count}" unless embed_script_count == 1
   end
 
   if fm["pdf_url"] || fm["pdf"]
@@ -115,9 +141,9 @@ Dir.glob(File.join(ROOT, "content", "blogs", "*", "index.md")).sort.each do |pat
 end
 
 if errors.any?
-  warn "Google Scholar metadata validation failed:"
+  warn "Scholar and Altmetric metadata validation failed:"
   errors.each { |error| warn "  - #{error}" }
   exit 1
 end
 
-puts "Google Scholar metadata validation passed."
+puts "Scholar and Altmetric metadata validation passed."

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ The `Deploy Hugo Site` workflow syncs Zenodo DOI metadata for accepted blog post
 
 To publish a new version of a post, update the post content and increment its `revision` frontmatter. Zenodo creates a new numeric version DOI under the same concept record, for example `https://doi.org/10.5281/zenodo.20277035`; it does not create `v2` or `v3` DOI URL suffixes. Frontmatter `doi` and `zenodo_url` values are still supported as manual fallback fields, but maintainers should normally leave them blank and let `data/zenodo.json` be the source of truth.
 
+Accepted posts with a DOI display an Altmetric badge for the current version. The badge uses the same DOI resolved from `data/zenodo.json` (or the frontmatter fallback) as the citation and Scholar metadata; posts without a DOI do not load the Altmetric embed script. Altmetric also requires the site domain and RSS feed to be registered as a tracked blog source through its [blog submission process](https://help.altmetric.com/en/articles/9801089).
+
 The archived DOI workflow validation post confirmed production v1/v2/v3 versioning and is now withdrawn from the public site.
 
 ## Manual Test Publish

--- a/layouts/partials/citation.html
+++ b/layouts/partials/citation.html
@@ -17,5 +17,17 @@
       <a href="{{ $doiURL }}" target="_blank" rel="noopener">{{ $doiURL }}</a>.
     {{- end }}
   </p>
+  {{ with $citationData.doi }}
+  <div class="citation-box__altmetric">
+    <span class="citation-box__altmetric-label">Online attention:</span>
+    <div class="altmetric-embed"
+         data-badge-type="medium-donut"
+         data-badge-details="right"
+         data-badge-popover="top"
+         data-link-target="_blank"
+         data-doi="{{ . }}"></div>
+  </div>
+  <script src="https://embed.altmetric.com/assets/embed.js" defer></script>
+  {{ end }}
 </div>
 <script src="{{ "js/citation.js" | relURL }}" defer></script>

--- a/layouts/partials/head/scholar-meta.html
+++ b/layouts/partials/head/scholar-meta.html
@@ -1,13 +1,5 @@
 {{- if and .IsPage (eq .Section "blogs") (eq .Params.status "accepted") -}}
 {{- $citation := partial "helper/citation-data.html" . -}}
-{{- $zenodoStore := hugo.Data.zenodo | default dict -}}
-{{- $zenodoEntry := dict -}}
-{{- with .Params.post_id -}}
-  {{- with index $zenodoStore . -}}
-    {{- $zenodoEntry = . -}}
-  {{- end -}}
-{{- end -}}
-{{- $zenodoDoi := $zenodoEntry.current_doi | default "" -}}
 {{- $publicationDate := .Params.date_accepted | default .Date -}}
 <meta name="citation_title" {{ printf "content=%q" $citation.title | safeHTMLAttr }}>
 {{- range $citation.authors }}
@@ -22,7 +14,7 @@
 <meta name="citation_online_date" content="{{ .Date | dateFormat "2006/01/02" }}">
 <meta name="citation_journal_title" {{ printf "content=%q" $citation.blogName | safeHTMLAttr }}>
 <meta name="citation_fulltext_html_url" content="{{ .Permalink }}">
-{{- with $zenodoDoi }}
+{{- with $citation.doi }}
 <meta name="citation_doi" {{ printf "content=%q" . | safeHTMLAttr }}>
 {{- end }}
 {{- with .Params.pdf_url | default .Params.pdf }}

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -814,6 +814,24 @@ article img {
   line-height: inherit;
 }
 
+.citation-box__altmetric {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+  min-height: 64px;
+}
+
+.citation-box__altmetric-label {
+  color: var(--card-text-color-secondary, #666);
+  font-size: 0.9em;
+  font-weight: 600;
+}
+
+.citation-box__altmetric .altmetric-embed {
+  flex: 0 0 auto;
+}
+
 .citation-box__versions {
   margin-top: 1rem;
 }


### PR DESCRIPTION
## Summary

- display an Altmetric attention badge for every blog post with a DOI
- resolve the badge and Scholar metadata from the current Zenodo DOI, with the existing frontmatter fallback
- avoid loading the Altmetric embed script on posts without a DOI
- add responsive styling and document the tracked-blog submission requirement
- extend generated-site validation to cover Altmetric DOI consistency and conditional script loading

## Code review

- no blocking findings
- confirmed the badge initializes with the expected DOI in a real desktop and mobile browser
- confirmed the component does not introduce the existing mobile page-width overflow
- confirmed the external script is loaded exactly once on DOI-backed posts and not loaded on posts without a DOI
- the Genomics x AI Blog and RSS feed have been submitted to Altmetric; source approval is pending

## Validation

- Hugo 0.164.0 production/minified build: passed (127 pages)
- Scholar and Altmetric metadata validation with strict accepted-DOI mode: passed
- Ruby syntax check: passed
- Git whitespace check: passed

Related to #82.
