### PR TITLE
Add Past Editorial Board section with history-preserving editors ledger

### DIFF
--- a/.github/scripts/fetch-editors.sh
+++ b/.github/scripts/fetch-editors.sh
@@ -1,5 +1,18 @@
 #!/usr/bin/env bash
-# Fetch the GitHub team roster into data/editors.json for Hugo rendering.
+# Sync the GitHub editors team into data/editors.json, preserving history.
+#
+# The GitHub Teams API only returns CURRENT members, so this script maintains a
+# persistent ledger. Current members are marked active; anyone previously in the
+# ledger but no longer on the team is marked as a past editor with an "end" year.
+# The deploy workflow commits the updated ledger back to the repo.
+#
+# Each ledger entry: { login, name, url, active, start, end }
+#   - start: first year the person was seen on the team
+#   - end:   year they left (null while active)
+#
+# IMPORTANT: if no token is available or the API call fails, the existing ledger
+# is left untouched — we never overwrite history with an empty list.
+#
 # Requires: GH_TOKEN with read:org, jq, curl.
 
 set -euo pipefail
@@ -8,18 +21,25 @@ ORG="${ORG:-genomicsxai}"
 TEAM="${TEAM:-editors}"
 OUT="${OUT:-data/editors.json}"
 TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
+YEAR="${EDITORS_YEAR:-$(date -u +%Y)}"
 
 mkdir -p "$(dirname "$OUT")"
 
+# Load the existing ledger; treat missing/invalid as empty.
+if [ -f "$OUT" ] && jq -e . "$OUT" >/dev/null 2>&1; then
+  LEDGER=$(cat "$OUT")
+else
+  LEDGER="[]"
+fi
+
 if [ -z "$TOKEN" ]; then
-  echo '[]' > "$OUT"
-  echo "No GH_TOKEN or GITHUB_TOKEN set; editorial board will be empty."
+  echo "No GH_TOKEN or GITHUB_TOKEN set; leaving existing editor ledger unchanged."
   exit 0
 fi
 
+# --- Fetch current team roster (paginated) ---
 PAGE=1
 ALL=""
-
 while true; do
   RES=$(curl -s -w "\n%{http_code}" \
     -H "Authorization: Bearer $TOKEN" \
@@ -29,8 +49,7 @@ while true; do
   BODY=$(echo "$RES" | sed '$d')
 
   if [ "$CODE" != "200" ]; then
-    echo "GitHub API returned $CODE; writing empty editors list."
-    echo '[]' > "$OUT"
+    echo "GitHub API returned $CODE; leaving existing editor ledger unchanged."
     exit 0
   fi
 
@@ -47,7 +66,10 @@ while true; do
   PAGE=$((PAGE + 1))
 done
 
-OUT_JSON="[]"
+[ -z "$ALL" ] && ALL="[]"
+
+# --- Resolve name/url for each current member ---
+CURRENT="[]"
 for login in $(echo "$ALL" | jq -r '.[].login'); do
   USER=$(curl -s \
     -H "Authorization: Bearer $TOKEN" \
@@ -58,8 +80,47 @@ for login in $(echo "$ALL" | jq -r '.[].login'); do
   [ -z "$URL" ] && URL="https://github.com/${login}"
   ENTRY=$(jq -nc --arg login "$login" --arg url "$URL" --arg name "$NAME" \
     '{login: $login, url: $url, name: (if $name == "" then null else $name end)}')
-  OUT_JSON=$(echo "$OUT_JSON" "$ENTRY" | jq -s '.[0] + [.[1]]')
+  CURRENT=$(echo "$CURRENT" "$ENTRY" | jq -s '.[0] + [.[1]]')
 done
 
+# --- Merge current roster into the ledger ---
+# Existing entries for current members: refresh name/url, keep start, active=true.
+# Existing entries no longer on the team: active=false, stamp end year once.
+# Brand-new current members: add with start = this year.
+OUT_JSON=$(jq -n \
+  --argjson ledger "$LEDGER" \
+  --argjson current "$CURRENT" \
+  --argjson year "$YEAR" '
+  ($current | map({key: .login, value: .}) | from_entries) as $cur
+  | ($current | map(.login)) as $curLogins
+  | ($ledger | map(
+      .login as $l
+      | if ($curLogins | index($l)) then
+          . + {
+            name:   $cur[$l].name,
+            url:    $cur[$l].url,
+            active: true,
+            start:  (.start // $year),
+            end:    null
+          }
+        else
+          . + {
+            active: false,
+            start:  (.start // $year),
+            end:    (.end // $year)
+          }
+        end
+    )) as $updated
+  | ($updated | map(.login)) as $known
+  | $updated
+    + ($current
+        | map(select(.login as $l | ($known | index($l)) | not))
+        | map(. + { active: true, start: $year, end: null }))
+  | sort_by([ (if .active then 0 else 1 end),
+              ((.name // .login) | ascii_downcase) ])
+')
+
 echo "$OUT_JSON" > "$OUT"
-echo "Fetched $(jq length "$OUT") editor(s) into $OUT."
+ACTIVE=$(echo "$OUT_JSON" | jq '[.[] | select(.active)] | length')
+PAST=$(echo "$OUT_JSON" | jq '[.[] | select(.active | not)] | length')
+echo "Synced editors ledger into $OUT: ${ACTIVE} active, ${PAST} past."

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths-ignore:
       - 'data/zenodo.json'
+      - 'data/editors.json'
 
 concurrency:
   group: deploy-main
@@ -57,6 +58,22 @@ jobs:
         run: |
           chmod +x .github/scripts/fetch-editors.sh
           ./.github/scripts/fetch-editors.sh
+
+      # 2.5b. Commit the editors ledger back so past editors persist across deploys
+      - name: Commit editors ledger
+        env:
+          GH_TOKEN: ${{ secrets.GH_CONTENTS_WRITE_TOKEN || github.token }}
+        run: |
+          if [ -z "$(git status --porcelain -- data/editors.json)" ]; then
+            echo "No editor ledger changes to commit."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
+          git add data/editors.json
+          git commit -m "chore: sync editors ledger"
+          git push
 
       # 2.6. Sync Zenodo DOI metadata for accepted blog posts changed in this push
       - name: Detect changed blog posts

--- a/content/page/editorial-board/index.md
+++ b/content/page/editorial-board/index.md
@@ -45,6 +45,12 @@ Review follows the [Minimal Editorial Review (MVR) framework](/editorial-review/
 
 {{< editors-list >}}
 
+### Past Editorial Board
+
+With gratitude to former members of the Editorial Board for their service.
+
+{{< past-editors >}}
+
 ### Becoming Involved
 
 If you are interested in:

--- a/layouts/shortcodes/editors-list.html
+++ b/layouts/shortcodes/editors-list.html
@@ -1,7 +1,10 @@
-{{- $editors := site.Data.editors -}}
-{{- if $editors -}}
+{{- $active := slice -}}
+{{- range site.Data.editors -}}
+  {{- if ne .active false -}}{{- $active = $active | append . -}}{{- end -}}
+{{- end -}}
+{{- if $active -}}
 <ul class="editors-list">
-  {{- range $editors -}}
+  {{- range $active -}}
   {{- $e := . -}}
   <li>
     <a href="{{ $e.url | default (printf "https://github.com/%s" $e.login) }}" target="_blank" rel="noopener" class="link">

--- a/layouts/shortcodes/past-editors.html
+++ b/layouts/shortcodes/past-editors.html
@@ -1,0 +1,26 @@
+{{- /* Renders former editorial board members (active: false) with the year(s) they served. */ -}}
+{{- $past := slice -}}
+{{- range site.Data.editors -}}
+  {{- if eq .active false -}}{{- $past = $past | append . -}}{{- end -}}
+{{- end -}}
+{{- if $past -}}
+<ul class="editors-list editors-list--past">
+  {{- range $past -}}
+  {{- $e := . -}}
+  {{- $s := "" -}}{{- $en := "" -}}
+  {{- with $e.start }}{{ $s = int . }}{{ end -}}
+  {{- with $e.end }}{{ $en = int . }}{{ end -}}
+  {{- $years := "" -}}
+  {{- if and (ne $s "") (ne $en "") -}}
+    {{- if eq $s $en -}}{{ $years = printf "%d" $s }}{{- else -}}{{ $years = printf "%d–%d" $s $en }}{{- end -}}
+  {{- else if ne $s "" -}}{{ $years = printf "%d" $s }}{{- end -}}
+  <li>
+    <a href="{{ $e.url | default (printf "https://github.com/%s" $e.login) }}" target="_blank" rel="noopener" class="link">
+      {{- if $e.name }}{{ $e.name }} <span class="editors-username">(@{{ $e.login }})</span>{{ else }}{{ $e.login }}{{ end -}}
+    </a>{{ with $years }} <span class="editors-years">— {{ . }}</span>{{ end }}
+  </li>
+  {{- end -}}
+</ul>
+{{- else -}}
+<p class="editors-source">No past editorial board members yet.</p>
+{{- end -}}

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -853,6 +853,12 @@ article img {
   font-weight: normal;
 }
 
+/* Past editorial board: mute the year(s) served */
+.editors-list .editors-years {
+  font-size: 0.9em;
+  color: var(--card-text-color-secondary, #666);
+}
+
 /* PhotoSwipe lightbox: zoom in/out buttons in toolbar */
 .pswp__button--zoom-in,
 .pswp__button--zoom-out {


### PR DESCRIPTION
Adds a **Past Editorial Board** section to the Editorial Board page. `data/editors.json` becomes a persistent ledger: current team members are marked `active`, and anyone removed is flipped to a past editor with an `end` year. The deploy workflow commits the ledger back so history survives (and `data/editors.json` is added to `paths-ignore` to avoid redeploy loops). A new `past-editors` shortcode renders former editors with name, GitHub link, and year(s) served.

Verified locally: jq merge logic across seed → remove → re-add → multi-year departure, and Hugo build rendering (single year, year range, name-less fallback).

Note: the ledger seeds on the first deploy that has `GH_EDITORS_TOKEN`; seed before removing anyone so removed members have a record to flip.