### PR TITLE
Add manual deploy trigger (workflow_dispatch)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,9 @@ on:
       - main
     paths-ignore:
       - 'data/zenodo.json'
+  # Allow manual redeploys (e.g. to refresh the editorial board after a GitHub
+  # team change, which does not itself push to main).
+  workflow_dispatch:
 
 concurrency:
   group: deploy-main


### PR DESCRIPTION
Lets us redeploy on demand — needed to refresh the editorial board after a GitHub team change, since team edits don't push to main.