### PR TITLE
Fix 2026-010 homepage ordering + make disciplines catch-all

### DIFF
--- a/.github/workflows/credit-reviewers.yml
+++ b/.github/workflows/credit-reviewers.yml
@@ -10,6 +10,10 @@ name: Credit PR reviewers
 # `editor:` is a metadata-only field (not rendered on the site), stored as a
 # YAML flow list, e.g. `editor: ["dwgoblue", "Al-Murphy"]`. A legacy single
 # string value is migrated to a one-item list the first time it is touched.
+#
+# This workflow also stamps `date:` (the homepage sort key) with the publish
+# date = the PR merge date, but only for posts newly ADDED by the PR, so
+# "first published" ordering stays correct without manual date-keeping.
 
 on:
   pull_request_target:
@@ -141,6 +145,63 @@ jobs:
               print(f"{path}: credited {to_add}")
           PYEOF
 
+      # Stamp `date:` (the field the homepage orders by) with the actual publish
+      # date = the PR merge date, but ONLY for posts newly ADDED by this PR. This
+      # keeps "first published" ordering correct without relying on authors
+      # setting date by hand. Edits/re-merges never touch an existing post's date.
+      - name: Set publish date on newly added posts
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number || github.event.inputs.pr }}
+        run: |
+          python3 - <<'PYEOF'
+          import os, re, subprocess
+
+          repo = os.environ["REPO"]
+          pr = os.environ["PR"]
+
+          def gh(path, jq):
+              return subprocess.run(
+                  ["gh", "api", "--paginate", path, "-q", jq],
+                  capture_output=True, text=True, check=True,
+              ).stdout
+
+          merged_at = gh(f"/repos/{repo}/pulls/{pr}", ".merged_at").strip()
+          if not merged_at or merged_at == "null":
+              print("PR is not merged — skipping publish-date step.")
+              raise SystemExit(0)
+          pub_date = merged_at[:10]  # YYYY-MM-DD
+
+          added = [f.strip() for f in
+                   gh(f"/repos/{repo}/pulls/{pr}/files",
+                      '.[] | select(.status=="added") | .filename').splitlines()
+                   if re.match(r"^content/blogs/[^/]+/index\.md$", f.strip())]
+          if not added:
+              print("No newly added blog posts in this PR — nothing to date.")
+              raise SystemExit(0)
+
+          for path in added:
+              if not os.path.exists(path):
+                  continue
+              with open(path, encoding="utf-8") as f:
+                  text = f.read()
+              # Match only the top-level `date:` line (revision_history dates are
+              # indented; date_submitted/date_accepted have a different key).
+              m = re.search(r"^(date:[ \t]*)(.*)$", text, re.MULTILINE)
+              if not m:
+                  print(f"WARNING: no date: field in {path}, skipping.")
+                  continue
+              current = m.group(2).strip()
+              if current == pub_date:
+                  print(f"{path}: date already {pub_date}.")
+                  continue
+              text = text[:m.start()] + m.group(1) + pub_date + text[m.end():]
+              with open(path, "w", encoding="utf-8") as f:
+                  f.write(text)
+              print(f"{path}: set date -> {pub_date} (was {current or 'empty'})")
+          PYEOF
+
       - name: Commit and push
         run: |
           if [ -z "$(git status --porcelain -- content/blogs)" ]; then
@@ -152,5 +213,5 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           # origin is an SSH remote (deploy key from checkout above); pushes to main.
           git add content/blogs/*/index.md
-          git commit -m "chore: credit reviewers on merged PR #${PR}"
+          git commit -m "chore: post-merge frontmatter for PR #${PR} (reviewers, publish date)"
           git push origin HEAD:main

--- a/content/blogs/2026-010/index.md
+++ b/content/blogs/2026-010/index.md
@@ -31,7 +31,7 @@ status: "submitted"
 revision: 1
 date_submitted: 2026-06-23
 date_accepted:
-date: 2026-06-17
+date: 2026-07-17
 doi: ""
 zenodo_url: ""
 revision_history:

--- a/data/disciplines.yaml
+++ b/data/disciplines.yaml
@@ -3,29 +3,43 @@
 # the existing `tags:` field in frontmatter; this list defines which tags are
 # elevated to first-class "discipline" status in the UI.
 #
-# The label is what the reader sees. The slug must match the urlized form of
-# the tag in post frontmatter (e.g. `tags: ["seq2func"]`).
+# The label is what the reader sees. The slug is the canonical/preferred tag
+# (urlized form, e.g. `tags: ["seq2func"]`).
+#
+# Optional `aliases:` lists extra tag slugs that should ALSO count toward the
+# same discipline — a catch-all so posts tagged with any common variant surface
+# under one discipline without every author having to use the exact slug. The
+# homepage discipline filter matches a post if it carries the slug OR any alias.
+# Slugs/aliases are compared in urlized form (lowercase, spaces→dashes).
 
 - label: "Sequence-to-Function Modeling"
   slug: "seq2func"
+  aliases: ["sequence-to-function", "seq-to-function", "seq2function", "sequence-to-function-modeling", "s2f", "sequence-to-activity", "seq-to-activity", "seq2activity", "seq2act"]
 
 - label: "Context-aware Seq-to-Function"
   slug: "context-seq2func"
+  aliases: ["context-aware-seq2func", "contextual-seq2func", "context-seq-to-function", "context-aware-sequence-to-function"]
 
 - label: "Single-cell Modeling"
   slug: "single-cell"
+  aliases: ["single-cell-modeling", "single-cell-genomics", "singlecell", "sc-modeling", "scrna-seq", "scrna", "single-cell-rna-seq"]
 
 - label: "Synthetic Biology"
   slug: "synthetic-biology"
+  aliases: ["synbio", "synthetic-bio", "syn-bio"]
 
 - label: "Interpretability / Mech AI"
   slug: "interpretability"
+  aliases: ["mechanistic-interpretability", "mech-interp", "interpretable-ai", "explainability", "explainable-ai", "mechanistic-ai"]
 
 - label: "Multi-omics"
   slug: "multi-omics"
+  aliases: ["multiomics", "multi-omic", "multiomic", "multi-modal-omics"]
 
 - label: "Experimental Design Loop"
   slug: "experimental-design"
+  aliases: ["experimental-design-loop", "active-learning", "design-loop", "ai-driven-experimental-design", "closed-loop-design"]
 
 - label: "AI Agents"
   slug: "ai-agents"
+  aliases: ["agentic-ai", "ai-agent", "agents", "llm-agents", "agentic", "agent"]

--- a/layouts/partials/widget/category-pills.html
+++ b/layouts/partials/widget/category-pills.html
@@ -57,14 +57,21 @@
        class="category-pills__pill{{ if eq $currentDisc "all" }} category-pills__pill--active{{ end }}"
        data-filter="all">All</a>
     {{- range site.Data.disciplines }}
-      {{- $isActive := eq $currentDisc .slug -}}
-      {{- $termPage := site.GetPage (printf "/tags/%s" .slug) -}}
+      {{- /* canonical slug + any aliases all count toward this discipline */ -}}
+      {{- $slugs := slice .slug -}}
+      {{- with .aliases }}{{ $slugs = $slugs | append . }}{{ end -}}
+      {{- $isActive := in $slugs $currentDisc -}}
+      {{- /* link to the first alias that has a real tag-archive page (prefer canonical) */ -}}
+      {{- $termPage := false -}}
+      {{- range $slugs -}}
+        {{- if not $termPage -}}{{- with site.GetPage (printf "/tags/%s" .) }}{{ $termPage = . }}{{ end -}}{{- end -}}
+      {{- end -}}
       {{- if $termPage }}
     <a href="{{ $termPage.Permalink }}"
        class="category-pills__pill{{ if $isActive }} category-pills__pill--active{{ end }}"
-       data-filter="{{ .slug }}">{{ .label }}</a>
+       data-filter="{{ .slug }}" data-filter-aliases="{{ delimit $slugs " " }}">{{ .label }}</a>
       {{- else }}
-    <span class="category-pills__pill category-pills__pill--empty" data-filter="{{ .slug }}" aria-disabled="true">{{ .label }}</span>
+    <span class="category-pills__pill category-pills__pill--empty" data-filter="{{ .slug }}" data-filter-aliases="{{ delimit $slugs " " }}" aria-disabled="true">{{ .label }}</span>
       {{- end -}}
     {{- end }}
   </div>

--- a/layouts/partials/widget/taxonomy-filters.html
+++ b/layouts/partials/widget/taxonomy-filters.html
@@ -18,10 +18,17 @@
 <nav class="filter-bar">
   <h3 class="filter-bar__heading">Filter posts by&hellip;</h3>
 
-  {{- /* Discipline dropdown — only show disciplines whose tag-archive page exists */ -}}
+  {{- /* Discipline dropdown — show a discipline if its canonical slug OR any
+         alias has a tag-archive page; link to the first such archive (prefer
+         canonical). The homepage pill filter aggregates all aliases client-side. */ -}}
   {{- $availableDisciplines := slice -}}
   {{- range $disciplines -}}
-    {{- $termPage := site.GetPage (printf "/tags/%s" .slug) -}}
+    {{- $slugs := slice .slug -}}
+    {{- with .aliases }}{{ $slugs = $slugs | append . }}{{ end -}}
+    {{- $termPage := false -}}
+    {{- range $slugs -}}
+      {{- if not $termPage -}}{{- with site.GetPage (printf "/tags/%s" .) }}{{ $termPage = . }}{{ end -}}{{- end -}}
+    {{- end -}}
     {{- if $termPage -}}
       {{- $availableDisciplines = $availableDisciplines | append (dict "label" .label "page" $termPage) -}}
     {{- end -}}

--- a/static/js/category-filter.js
+++ b/static/js/category-filter.js
@@ -22,6 +22,14 @@
     });
   });
 
+  // A pill can stand for several tag slugs (a discipline "catch-all"): the
+  // canonical slug plus any aliases, carried in data-filter-aliases. Fall back
+  // to the single data-filter value for pills without aliases (e.g. categories).
+  function aliasesOf(el) {
+    var raw = el.getAttribute('data-filter-aliases') || el.getAttribute('data-filter') || '';
+    return raw.split(' ').filter(Boolean);
+  }
+
   // Pass 2: replace each <a>/<span> pill with a <button>; mark empty pills as
   // disabled.
   groups.forEach(function (group) {
@@ -35,6 +43,8 @@
       var btn = document.createElement('button');
       btn.className = pill.className;
       btn.setAttribute('data-filter', pill.getAttribute('data-filter'));
+      var aliasAttr = pill.getAttribute('data-filter-aliases');
+      if (aliasAttr) btn.setAttribute('data-filter-aliases', aliasAttr);
       btn.textContent = pill.textContent;
       btn.type = 'button';
 
@@ -44,7 +54,10 @@
       }
 
       var filter = btn.getAttribute('data-filter');
-      var isEmpty = filter !== 'all' && !presentSet.has(filter);
+      // Empty when the pill matches no visible post via ANY of its alias slugs.
+      var isEmpty = filter !== 'all' && !aliasesOf(btn).some(function (s) {
+        return presentSet.has(s);
+      });
       if (isEmpty) {
         btn.classList.add('category-pills__pill--empty');
         btn.disabled = true;
@@ -70,7 +83,9 @@
         var f = activeFilters[group];
         if (f === 'all') return;
         var pool = group === 'discipline' ? tags : cats;
-        if (pool.indexOf(f) === -1) visible = false;
+        // f is an array of alias slugs; a post matches if it carries ANY of them.
+        var matched = f.some(function (s) { return pool.indexOf(s) !== -1; });
+        if (!matched) visible = false;
       });
       article.hidden = !visible;
       if (visible) visibleCount++;
@@ -88,7 +103,7 @@
       var btn = event.target.closest('.category-pills__pill');
       if (!btn || btn.disabled) return;
 
-      activeFilters[groupName] = btn.getAttribute('data-filter');
+      activeFilters[groupName] = btn.getAttribute('data-filter') === 'all' ? 'all' : aliasesOf(btn);
 
       var groupButtons = group.querySelectorAll('.category-pills__pill');
       groupButtons.forEach(function (b) {


### PR DESCRIPTION
**Homepage ordering (2026-010)**
The homepage sorts by the `date` field. 2026-010 ("Chorus") had `date: 2026-06-17` — older than its own submission date and earlier than 2026-011/2026-007 — so it appeared 3rd despite going live 2026-07-17. Corrected its `date` to the publish date so it sorts first.

**No recurrence** — the post-merge workflow (`credit-reviewers.yml`) now stamps `date:` with the PR merge date for posts newly *added* by the PR (never touches existing posts' dates), so first-published ordering stays correct without manual date-keeping.

**Disciplines as catch-alls**
Each discipline in `data/disciplines.yaml` gets an optional `aliases` list of extra tag slugs that count toward it. The homepage pill filter now matches a post if it carries the canonical slug **or any alias**; pill availability and the sidebar dropdown are alias-aware too. So "AI Agents" now surfaces the Chorus post (tagged `agentic-ai`), and e.g. Sequence-to-Function also matches `sequence-to-activity`/`seq2act`.

Verified via local build: 2026-010 now renders first (datetime 2026-07-17); the AI Agents pill renders live, links to `/tags/agentic-ai/`, and carries its full alias set; JS + embedded workflow python syntax-checked.