### PR TITLE
Fix article pages overflowing the viewport on mobile

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -245,6 +245,19 @@
   margin-right: auto;
   background: var(--card-background);
 }
+/* Mobile/tablet: make the card fill the main column instead of shrink-wrapping.
+   The auto side margins above are cross-axis auto margins on a flex item of
+   `main.main` (a column flexbox), which suppresses `align-self: stretch`. The
+   card then sizes to its content (~672px, driven by .article-content's 42em)
+   and overflows the viewport, forcing the whole page to zoom out. */
+@media (max-width: 1023.98px) {
+  .article-page .main-article {
+    width: 100%;
+    max-width: 100%;
+    margin-left: 0;
+    margin-right: 0;
+  }
+}
 .article-page .main-article .article-details .article-title {
   color: var(--card-text-color-main);
 }


### PR DESCRIPTION
## Problem

On mobile, the homepage fits fine but tapping into an article gives a page wider than the screen — you have to zoom out to read it.

## Root cause

`.article-page .main-article` (in `static/css/custom.css`) centres the white card on desktop with `margin-left/right: auto` and `max-width: 780px`.

That card is a flex item of `main.main`, which is a **column** flexbox. Per the flexbox spec, `auto` margins on the cross axis suppress `align-self: stretch` — so instead of filling its parent, the card sized itself to its own content: **~672px**, driven by `.article-content { max-width: 42em }`.

`main.main` was sized correctly the whole time. Measured at a 390px viewport before the fix:

| | width |
|---|---|
| viewport | 390px |
| `main.main` | 360px ✅ |
| `.main-article` | **672px** ❌ |
| `document.scrollWidth` | **687px** ❌ |

## Fix

Below the `lg` breakpoint, let the card fill its column:

```css
@media (max-width: 1023.98px) {
  .article-page .main-article {
    width: 100%;
    max-width: 100%;
    margin-left: 0;
    margin-right: 0;
  }
}
```

Mobile-only, as requested — desktop (>= 1024px) renders byte-for-byte identically.

## Verification

Measured in headless Chrome at **360 / 390 / 430 / 768 / 1024 / 1440px** across `2026-002`, `2026-007`, `2026-010`, the homepage, and a static page. `document.scrollWidth === clientWidth` at every combination after the fix (before: 687px at all three phone widths, 956px at 768px).

Also confirmed the wide content inside articles still *scrolls* rather than being clipped — e.g. the table in `2026-007` at 390px reports `clientWidth 318 / scrollWidth 434` with `overflow-x: auto`. Code blocks likewise.

| Before (390px) | After (390px) |
|---|---|
| Title clipped, body text running off-screen | Card fits the column, title wraps, all text visible |

## Out of scope (pre-existing, not touched)

Two things surfaced while measuring that this PR deliberately leaves alone:

1. **1024–1279px**: the card computes to 714px inside a 584px column, so it overlaps the sidebar gutter. It doesn't cause page-level scroll, so it isn't the reported bug — but it's the same root cause and could be folded in if you want.
2. **`.author-tooltip`** (`min-width: 264px`, absolutely positioned) gets clipped by the card's `overflow: hidden` on narrow screens. It's hover-driven so it's mostly moot on touch, but it won't display properly if triggered via `:focus-within`.