### PR TITLE
Mark published posts 2026-009/010/011 as accepted (mint Zenodo DOIs)

### DIFF
--- a/content/blogs/2026-009/index.md
+++ b/content/blogs/2026-009/index.md
@@ -25,7 +25,7 @@ scope: ["insights"]
 audience: ["within-field"]
 labs: ["Dias and Frazer lab"]
 
-status: "submitted"
+status: "accepted"
 revision: 3
 
 date_submitted: 2026-05-24

--- a/content/blogs/2026-010/index.md
+++ b/content/blogs/2026-010/index.md
@@ -27,7 +27,7 @@ scope: ["insights", "tutorials"]
 audience: ["intro-to-field", "general"]
 disciplines: ["Sequence-to-Function Modeling"]
 labs: ["Pinello Lab"]
-status: "submitted"
+status: "accepted"
 revision: 1
 date_submitted: 2026-06-23
 date_accepted:

--- a/content/blogs/2026-011/index.md
+++ b/content/blogs/2026-011/index.md
@@ -50,7 +50,7 @@ scope: ["insights", "tutorials"]
 audience: ["within-field"]
 labs: ["Programmable Genomics Laboratory"]
 
-status: "submitted"
+status: "accepted"
 revision: 2
 
 date_submitted: 2026-07-13


### PR DESCRIPTION
## Why

2026-009, 2026-010, and 2026-011 are merged and live, but their frontmatter still says `status: "submitted"`. The deploy-time Zenodo sync only mints DOIs for `accepted` posts:

```ruby
# .github/scripts/sync-zenodo-dois.rb:203
next unless frontmatter["status"].to_s == "accepted"
```

So these three were silently skipped on every deploy, no `data/zenodo.json` entry was written, and their **citation boxes render with no DOI**. (The `doi.org/10.1038…` / `10.1101…` links visible on those pages are in-article references to other papers — not the post's own Zenodo DOI.)

By contrast, 2026-001–008 are all `accepted`/`withdrawn` and have DOIs. This just brings the three newest published posts in line with their actual state.

## Change

`status: "submitted"` → `status: "accepted"` on all three `index.md` files. Nothing else.

## What happens on merge

The existing auto-sync in `deploy.yml` (step 2.6) detects the changed `index.md` files, and because they're now `accepted`, `sync-zenodo-dois.rb` mints a Zenodo DOI for each and commits `data/zenodo.json` back to main. **This registers three real, permanent Zenodo records** — that's the intended outcome, but worth stating explicitly.

## Verification

Dry-run of the real sync script against the branch:

```
[DRY RUN] Would sync Zenodo DOI for 2026-009 revision 3
[DRY RUN] Would sync Zenodo DOI for 2026-010 revision 1
[DRY RUN] Would sync Zenodo DOI for 2026-011 revision 2
```

Before the flip, all three produce no output (skipped). `validate-blog.sh` passes.

Each post gets a DOI for its **current** revision (009 is at rev 3, 011 at rev 2), matching how first-time syncs already work elsewhere (e.g. 2026-005 registered at rev 2). Earlier revisions are not backfilled.

## Companion PR

A separate PR automates this flip on future merges (in `credit-reviewers.yml`, alongside the existing reviewer/publish-date stamping) so a published post can't go live as `submitted` again — which is the root cause here.