### PR TITLE
Auto-accept merged posts + document all editorial automation

### DIFF
--- a/.github/workflows/credit-reviewers.yml
+++ b/.github/workflows/credit-reviewers.yml
@@ -14,6 +14,12 @@ name: Credit PR reviewers
 # This workflow also stamps `date:` (the homepage sort key) with the publish
 # date = the PR merge date, but only for posts newly ADDED by the PR, so
 # "first published" ordering stays correct without manual date-keeping.
+#
+# Finally, it flips `status: "submitted"` -> `"accepted"` on any changed post,
+# marking it published. This is what lets the deploy-time Zenodo sync mint a
+# DOI: sync-zenodo-dois.rb skips posts that aren't `accepted`, so a post merged
+# while still `submitted` would otherwise go live without one. Only `submitted`
+# is touched — `withdrawn` and `accepted` are left as-is.
 
 on:
   pull_request_target:
@@ -202,6 +208,57 @@ jobs:
               print(f"{path}: set date -> {pub_date} (was {current or 'empty'})")
           PYEOF
 
+      # Mark merged posts as published. The deploy-time Zenodo sync only mints a
+      # DOI for posts with status: "accepted" (sync-zenodo-dois.rb), so a post
+      # merged while still "submitted" goes live without a DOI. Flip it here.
+      # Only "submitted" is touched — "withdrawn" and "accepted" are left alone.
+      - name: Mark merged posts as accepted
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number || github.event.inputs.pr }}
+        run: |
+          python3 - <<'PYEOF'
+          import os, re, subprocess
+
+          repo = os.environ["REPO"]
+          pr = os.environ["PR"]
+
+          def gh(path, jq):
+              return subprocess.run(
+                  ["gh", "api", "--paginate", path, "-q", jq],
+                  capture_output=True, text=True, check=True,
+              ).stdout
+
+          changed = [f.strip() for f in
+                     gh(f"/repos/{repo}/pulls/{pr}/files", ".[].filename").splitlines()
+                     if re.match(r"^content/blogs/[^/]+/index\.md$", f.strip())]
+          if not changed:
+              print("No blog posts changed in this PR — nothing to mark accepted.")
+              raise SystemExit(0)
+
+          for path in changed:
+              if not os.path.exists(path):
+                  continue
+              with open(path, encoding="utf-8") as f:
+                  text = f.read()
+              # Only the top-level `status:` line. revision_history entries carry
+              # no status key, and would be indented even if they did, so an
+              # anchored ^status: match can't touch them.
+              m = re.search(r"^(status:[ \t]*)(.*)$", text, re.MULTILINE)
+              if not m:
+                  print(f"WARNING: no status: field in {path}, skipping.")
+                  continue
+              value = m.group(2).strip().strip('"').strip("'")
+              if value != "submitted":
+                  print(f"{path}: status is {value!r}, leaving unchanged.")
+                  continue
+              text = text[:m.start()] + m.group(1) + '"accepted"' + text[m.end():]
+              with open(path, "w", encoding="utf-8") as f:
+                  f.write(text)
+              print(f"{path}: status submitted -> accepted")
+          PYEOF
+
       - name: Commit and push
         run: |
           if [ -z "$(git status --porcelain -- content/blogs)" ]; then
@@ -213,5 +270,5 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           # origin is an SSH remote (deploy key from checkout above); pushes to main.
           git add content/blogs/*/index.md
-          git commit -m "chore: post-merge frontmatter for PR #${PR} (reviewers, publish date)"
+          git commit -m "chore: post-merge frontmatter for PR #${PR} (reviewers, publish date, status)"
           git push origin HEAD:main

--- a/content/page/editorial-review/index.md
+++ b/content/page/editorial-review/index.md
@@ -12,6 +12,30 @@ Ensure posts are **accurate, readable, appropriately tagged, and safe to publish
 
 ---
 
+## What happens automatically (so you don't have to)
+
+Almost all of the mechanical work around a post is handled by CI. Your job is the **quality review** in the sections below — you do **not** need to edit frontmatter, set dates, change a post's status, mint DOIs, or set up its comment thread by hand. If you notice one of these fields is wrong on an incoming PR, fix it or ask the author, but you never have to touch them just to get a post published.
+
+**While a PR is open** (re-runs on every push to the PR):
+
+* **Build check** — the site is rebuilt to confirm the post compiles.
+* **Frontmatter validation** — required fields and formatting are checked.
+* **Link check** — broken links are flagged.
+* **Preview deployment** — an unlisted preview of the post (`noindex`, not linked from the blog) is built and its URL posted as a PR comment. It updates on each new commit and is deleted when the PR closes.
+
+**When the PR is merged:**
+
+* **Reviewer credit** — every editor who engaged with the PR (a formal review, a review comment, or a conversation comment) is added to the post's `editor:` list. Only `@genomicsxai/editors` members are credited, so authors and other commenters never are. See [§3](#3-review-outcomes).
+* **Publish date** — `date:` (the field the homepage orders by) is stamped with the merge date, for newly added posts, so "first published" ordering stays correct.
+* **Acceptance** — `status:` is flipped from `submitted` to `accepted`. A post already marked `withdrawn` or `accepted` is left untouched.
+* **Zenodo DOI** — each accepted post is issued a Zenodo DOI (or a new version, for an update), recorded in `data/zenodo.json` and shown in its citation box. This only happens once the post is `accepted` — which is why the automatic flip above matters. See [§1H](#h-references-and-google-scholar-indexing).
+* **GitHub Discussion** — a discussion thread is created to back the post's comments and likes.
+* **Google Scholar metadata + publish** — Scholar/Highwire metadata is emitted and the site is rebuilt and deployed.
+
+**What this leaves for you:** the review itself — scope, correctness, clarity, tagging, and safety ([§1](#1-core-review-dimensions)); the executive summary ([§2](#2-executive-summary-requirement)); and a recommendation ([§3](#3-review-outcomes)). That's it.
+
+---
+
 ## 1. Core review dimensions
 
 ### A. Scope and relevance (fast gate)


### PR DESCRIPTION
Two coupled changes: the root-cause fix for posts publishing without a DOI, and the documentation the request also asked for.

## 1. Auto-mark merged blog posts as accepted

Published posts have been shipping without a Zenodo DOI because **nothing flips `status: "submitted"` → `"accepted"` when a post merges.** The deploy-time sync only mints DOIs for `accepted` posts:

```ruby
# .github/scripts/sync-zenodo-dois.rb:203
next unless frontmatter["status"].to_s == "accepted"
```

So a post merged while still `submitted` goes live with no DOI and no signal anything is wrong. 2026-009/010/011 all hit this — #111 fixes those three by hand; this stops it recurring.

**Change:** extend `credit-reviewers.yml` (which already stamps reviewers + publish date post-merge via the deploy key) with one step that flips `status: "submitted"` → `"accepted"` on every blog post changed by the merged PR.

- **Only `submitted` is rewritten** — `withdrawn`/`accepted` untouched (exact-value guard).
- **Top-level `status:` only** — anchored `^status:`; `revision_history` can't be touched.
- **No extra deploy cycle** — the flip lands in the same post-merge commit as the reviewer/date stamping; that same follow-up deploy now sees `accepted` and mints the DOI.

Unit-tested against real posts:

| post | before | result |
|---|---|---|
| 2026-009 | `submitted` | → `accepted` |
| 2026-010 | `submitted` | → `accepted` |
| 2026-006 | `withdrawn` | unchanged |
| 2026-001 | `accepted` | unchanged |

Only runs on future merges — no backfill; the already-merged three are handled by #111.

## 2. Document all editorial automation

New **"What happens automatically (so you don't have to)"** section near the top of the editorial review guide, consolidating every automated step so editors know the mechanical work isn't theirs:

- **Pre-merge:** build check, frontmatter validation, link check, preview deployment.
- **On merge:** reviewer credit, publish-date stamping, the new `submitted`→`accepted` flip, Zenodo DOI, GitHub Discussion creation, Scholar metadata + deploy.

It states plainly that the reviewer's only job is the quality review (§1), the executive summary (§2), and a recommendation (§3) — nothing mechanical. Cross-links the existing §3 and §1H callouts into one place.

Verified: site builds; all five in-page anchors the new section references resolve to real heading IDs.

## Relationship to #111

#111 = the one-time content fix (flip the three live posts, mint their DOIs). This PR = the durable fix + docs. Independent; merge in either order.