### PR TITLE
Recover lost Zenodo DOI metadata for 2026-009/010/011

### DIFF
--- a/data/zenodo.json
+++ b/data/zenodo.json
@@ -177,5 +177,62 @@
         "notes": "Initial Zenodo community token validation post"
       }
     }
+  },
+  "2026-009": {
+    "conceptrecid": "21535144",
+    "current_revision": 3,
+    "current_doi": "10.5281/zenodo.21535145",
+    "current_doi_url": "https://doi.org/10.5281/zenodo.21535145",
+    "current_zenodo_url": "https://zenodo.org/records/21535145",
+    "current_deposition_id": 21535145,
+    "revisions": {
+      "3": {
+        "doi": "10.5281/zenodo.21535145",
+        "doi_url": "https://doi.org/10.5281/zenodo.21535145",
+        "zenodo_url": "https://zenodo.org/records/21535145",
+        "deposition_id": 21535145,
+        "record_id": 21535145,
+        "date": "2026-07-24",
+        "notes": "Addressed reviewer/editor feedback: clarified trans-acting SF3B1/identical WT-mutant sequence input, coverage binning no-op, annotated vs. predicted junction positions, and compute footprint; reworked debugging section structure and the fine-tuning recipe; expanded figure legends."
+      }
+    }
+  },
+  "2026-010": {
+    "conceptrecid": "21535148",
+    "current_revision": 1,
+    "current_doi": "10.5281/zenodo.21535149",
+    "current_doi_url": "https://doi.org/10.5281/zenodo.21535149",
+    "current_zenodo_url": "https://zenodo.org/records/21535149",
+    "current_deposition_id": 21535149,
+    "revisions": {
+      "1": {
+        "doi": "10.5281/zenodo.21535149",
+        "doi_url": "https://doi.org/10.5281/zenodo.21535149",
+        "zenodo_url": "https://zenodo.org/records/21535149",
+        "deposition_id": 21535149,
+        "record_id": 21535149,
+        "date": "2026-06-23",
+        "notes": "Initial submission"
+      }
+    }
+  },
+  "2026-011": {
+    "conceptrecid": "21535160",
+    "current_revision": 2,
+    "current_doi": "10.5281/zenodo.21535161",
+    "current_doi_url": "https://doi.org/10.5281/zenodo.21535161",
+    "current_zenodo_url": "https://zenodo.org/records/21535161",
+    "current_deposition_id": 21535161,
+    "revisions": {
+      "2": {
+        "doi": "10.5281/zenodo.21535161",
+        "doi_url": "https://doi.org/10.5281/zenodo.21535161",
+        "zenodo_url": "https://zenodo.org/records/21535161",
+        "deposition_id": 21535161,
+        "record_id": 21535161,
+        "date": "2026-07-13",
+        "notes": "Minor revisions"
+      }
+    }
   }
 }


### PR DESCRIPTION
## Incident

Merging #111 and #112 ~20s apart caused the DOIs to be **minted but not recorded**.

- #111's deploy detected the three newly-`accepted` posts and ran the Zenodo sync, which **created and published** real DOIs (took ~67s).
- During those 67s, the #112 merge advanced `main`.
- The deploy then tried to commit `data/zenodo.json` with a plain `git push` from its now-stale checkout → **rejected, non-fast-forward**. The step is `continue-on-error: true`, so the deploy went green and the metadata commit (`1f6f4ffa`, "57 insertions") was silently dropped.

Net result: three published Zenodo records exist (the #111 build even shipped them to the live site), but `main`'s `zenodo.json` didn't capture them — so a fresh deploy fails Scholar validation (as #112's deploy did), and a naive re-sync would **mint duplicates**.

## Fix

The records are published and public, so I recovered their metadata from the Zenodo API (`zenodo.org/api/records/<id>`) rather than re-minting, and rebuilt the three entries with the same field logic as `sync-zenodo-dois.rb`:

| post | rev | DOI | concept |
|---|---|---|---|
| 2026-009 | 3 | `10.5281/zenodo.21535145` | 21535144 |
| 2026-010 | 1 | `10.5281/zenodo.21535149` | 21535148 |
| 2026-011 | 2 | `10.5281/zenodo.21535161` | 21535160 |

## Verification

- **57 insertions, entries only** — existing 001–008 untouched; byte-count identical to the dropped commit.
- **Build emits `citation_doi`** for all three → the Scholar validation that failed on #112's deploy now passes.
- **No duplicate risk:** a dry-run of the real sync now reports `No Zenodo metadata changes needed` for all three (the `revisions` map holds each post's current revision, so sync skips them).

Merging this changes **only `data/zenodo.json`**, so the resulting deploy runs no sync at all — it just rebuilds with correct data and republishes.

## Required follow-up (separate PR)

The root cause is in `deploy.yml`: it pushes `zenodo.json` to `main` from a stale checkout with a bare `git push` and swallows failure. It needs a fetch-rebase-retry loop so a concurrent merge can't orphan minted DOIs again. I'll open that next.